### PR TITLE
feat: 添加docker-compose并修复构建BUG

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: '3.6'
+services:
+
+  mongo:
+    image: mongo:4
+    container_name: xiaoju-survey-mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: 123456
+    ports:
+      - "27017:27017" # 数据库端口
+    volumes:
+      - mongo-volume:/data/db
+
+
+  xiaoju-survey:
+    image: "xiaoju-survey-app"  # docker build -t xiaoju-survey-app . 后即可获得该镜像
+    container_name: xiaoju-survey
+    restart: always
+    ports:
+      - "3000:3000" # API端口
+    environment:
+      xiaojuSurveyMongoUrl: mongodb://root:123456@mongo:27017 # 这里和上面mongo镜像的用户名密码保持一致即可
+      xiaojuSurveyJwtSecret: surveyEngineJwtSecret
+      xiaojuSurveyJwtExpiresIn: 8h
+    links:
+      - mongo:mongo
+    depends_on:
+      - mongo
+
+volumes:
+  mongo-volume:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,9 +5,6 @@ services:
     image: mongo:4
     container_name: xiaoju-survey-mongo
     restart: always
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: 123456
     ports:
       - "27017:27017" # 数据库端口
     volumes:
@@ -21,7 +18,7 @@ services:
     ports:
       - "3000:3000" # API端口
     environment:
-      xiaojuSurveyMongoUrl: mongodb://root:123456@mongo:27017 # 这里和上面mongo镜像的用户名密码保持一致即可
+      xiaojuSurveyMongoUrl: mongodb://mongo:27017 # 这里和上面mongo镜像的用户名密码保持一致即可
       xiaojuSurveyJwtSecret: surveyEngineJwtSecret
       xiaojuSurveyJwtExpiresIn: 8h
     links:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,9 @@ services:
     image: mongo:4
     container_name: xiaoju-survey-mongo
     restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME} # 默认使用系统的环境变量
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD} # 默认使用系统的环境变量
     ports:
       - "27017:27017" # 数据库端口
     volumes:
@@ -18,7 +21,7 @@ services:
     ports:
       - "3000:3000" # API端口
     environment:
-      xiaojuSurveyMongoUrl: mongodb://mongo:27017 # 这里和上面mongo镜像的用户名密码保持一致即可
+      xiaojuSurveyMongoUrl: ${xiaojuSurveyMongoUrl} # 默认使用系统的环境变量
       xiaojuSurveyJwtSecret: surveyEngineJwtSecret
       xiaojuSurveyJwtExpiresIn: 8h
     links:

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "survey server template",
   "main": "index.js",
   "scripts": {
-    "copy": "cp -rf ./src/* ./build/",
+    "copy": "mkdir -p ./build/ && cp -rf ./src/* ./build/",
     "build": "tsc",
     "launch:local": "npm run build && SERVER_ENV=local node ./build/index.js",
     "launch:dev": "npm run build && SERVER_ENV=dev node ./build/index.js",


### PR DESCRIPTION
使用方式：
1. 在我们构建了docker镜像xiaoju-survey-app后使用
2.后端我们将构建的镜像上传到hub.docker.com则可以无需构建docker镜像xiaoju-survey-app
目前我们暂时只支持第一种使用方式，构建完成我们项目的docker镜像后，可以直接使用以下命令进行运行
```sh
docker-compose up 
```
后续我们将使用说明补充到我们的帮助文档中