### PR TITLE
fix: 修复评分和nps题型非必填提示没有填写的问题

### DIFF
--- a/web/src/materials/questions/widgets/NpsModule/index.vue
+++ b/web/src/materials/questions/widgets/NpsModule/index.vue
@@ -17,13 +17,14 @@
     <QuestionWithRule
       v-if="isShowInput"
       :showTitle="false"
+      ref="withRuleRef"
       :moduleConfig="moduleConfig"
       @change="onMoreDataChange"
     ></QuestionWithRule>
   </div>
 </template>
 <script setup>
-import { defineProps, defineEmits, computed } from 'vue';
+import { defineProps, defineEmits, computed, ref, nextTick } from 'vue';
 import QuestionWithRule from '@/materials/questions/widgets/QuestionRuleContainer';
 import BaseRate from '../BaseRate';
 const props = defineProps({
@@ -65,6 +66,7 @@ const props = defineProps({
 const emit = defineEmits(['change']);
 
 const npsClass = !props.readonly ? 'radio-nps-hover' : '';
+const withRuleRef = ref(null);
 
 const rating = computed({
   get() {
@@ -82,6 +84,21 @@ const rating = computed({
 const confirmNps = (num) => {
   if (props.readonly) return;
   rating.value = num;
+  resetOthersError(num);
+};
+
+const resetOthersError = (num) => {
+  nextTick(() => {
+    const { required, othersKey } = props.rangeConfig[num];
+    if (
+      !required &&
+      othersKey &&
+      withRuleRef.value &&
+      withRuleRef.value.validateMessage
+    ) {
+      withRuleRef.value.validateMessage = '';
+    }
+  });
 };
 
 const minMsg = computed(() => {

--- a/web/src/materials/questions/widgets/NpsModule/index.vue
+++ b/web/src/materials/questions/widgets/NpsModule/index.vue
@@ -17,14 +17,14 @@
     <QuestionWithRule
       v-if="isShowInput"
       :showTitle="false"
-      ref="withRuleRef"
+      :key="`${props.field}_${rating}`"
       :moduleConfig="moduleConfig"
       @change="onMoreDataChange"
     ></QuestionWithRule>
   </div>
 </template>
 <script setup>
-import { defineProps, defineEmits, computed, ref, nextTick } from 'vue';
+import { defineProps, defineEmits, computed } from 'vue';
 import QuestionWithRule from '@/materials/questions/widgets/QuestionRuleContainer';
 import BaseRate from '../BaseRate';
 const props = defineProps({
@@ -66,7 +66,6 @@ const props = defineProps({
 const emit = defineEmits(['change']);
 
 const npsClass = !props.readonly ? 'radio-nps-hover' : '';
-const withRuleRef = ref(null);
 
 const rating = computed({
   get() {
@@ -84,21 +83,6 @@ const rating = computed({
 const confirmNps = (num) => {
   if (props.readonly) return;
   rating.value = num;
-  resetOthersError(num);
-};
-
-const resetOthersError = (num) => {
-  nextTick(() => {
-    const { required, othersKey } = props.rangeConfig[num];
-    if (
-      !required &&
-      othersKey &&
-      withRuleRef.value &&
-      withRuleRef.value.validateMessage
-    ) {
-      withRuleRef.value.validateMessage = '';
-    }
-  });
 };
 
 const minMsg = computed(() => {

--- a/web/src/materials/questions/widgets/StarModule/index.jsx
+++ b/web/src/materials/questions/widgets/StarModule/index.jsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, ref, nextTick } from 'vue';
+import { defineComponent, computed } from 'vue';
 import '../../common/css/radioStar.scss';
 import BaseRate from '../BaseRate';
 import QuestionWithRule from '@/materials/questions/widgets/QuestionRuleContainer';
@@ -54,7 +54,6 @@ export default defineComponent({
         });
       },
     });
-    const withRuleRef = ref(null);
     const currentRangeConfig = computed(() => {
       return props.rangeConfig[rating.value];
     });
@@ -77,20 +76,6 @@ export default defineComponent({
     const confirmStar = (num) => {
       if (props.readonly) return;
       rating.value = num;
-      resetOthersError(num);
-    };
-    const resetOthersError = (num) => {
-      nextTick(() => {
-        const { required, othersKey } = props.rangeConfig[num];
-        if (
-          !required &&
-          othersKey &&
-          withRuleRef.value &&
-          withRuleRef.value.validateMessage
-        ) {
-          withRuleRef.value.validateMessage = '';
-        }
-      });
     };
     const onMoreDataChange = (data) => {
       const { key, value } = data;
@@ -104,7 +89,6 @@ export default defineComponent({
       currentRangeConfig,
       starClass,
       isShowInput,
-      withRuleRef,
       confirmStar,
       onMoreDataChange,
     };
@@ -137,7 +121,7 @@ export default defineComponent({
         {isShowInput && (
           <QuestionWithRule
             showTitle={false}
-            ref={(el) => (this.withRuleRef = el)}
+            key={ `${this.field}_${this.rating}`}
             moduleConfig={{
               type: 'selectMoreModule',
               field: `${this.field}_${this.rating}`,

--- a/web/src/materials/questions/widgets/StarModule/index.jsx
+++ b/web/src/materials/questions/widgets/StarModule/index.jsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed } from 'vue';
+import { defineComponent, computed, ref, nextTick } from 'vue';
 import '../../common/css/radioStar.scss';
 import BaseRate from '../BaseRate';
 import QuestionWithRule from '@/materials/questions/widgets/QuestionRuleContainer';
@@ -54,6 +54,7 @@ export default defineComponent({
         });
       },
     });
+    const withRuleRef = ref(null);
     const currentRangeConfig = computed(() => {
       return props.rangeConfig[rating.value];
     });
@@ -76,8 +77,21 @@ export default defineComponent({
     const confirmStar = (num) => {
       if (props.readonly) return;
       rating.value = num;
+      resetOthersError(num);
     };
-
+    const resetOthersError = (num) => {
+      nextTick(() => {
+        const { required, othersKey } = props.rangeConfig[num];
+        if (
+          !required &&
+          othersKey &&
+          withRuleRef.value &&
+          withRuleRef.value.validateMessage
+        ) {
+          withRuleRef.value.validateMessage = '';
+        }
+      });
+    };
     const onMoreDataChange = (data) => {
       const { key, value } = data;
       emit('change', {
@@ -90,6 +104,7 @@ export default defineComponent({
       currentRangeConfig,
       starClass,
       isShowInput,
+      withRuleRef,
       confirmStar,
       onMoreDataChange,
     };
@@ -122,6 +137,7 @@ export default defineComponent({
         {isShowInput && (
           <QuestionWithRule
             showTitle={false}
+            ref={(el) => (this.withRuleRef = el)}
             moduleConfig={{
               type: 'selectMoreModule',
               field: `${this.field}_${this.rating}`,


### PR DESCRIPTION
1. 1.0分和1分均有更多输入框，0分的输入框必填、1分的输入框非必填，0分+输入框为空的情况会正常校验和提示，此时选择1分，输入框还是会有校验提示（提示应该消失）
2.评分题同理
![image](https://github.com/didi/xiaoju-survey/assets/27545556/9f1192d7-60ec-4dfe-8c6b-5c5e9db2769e)
