### PR TITLE
fix:前端项目使用nginx服务代理,不在使用后端服务代理

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 
 RUN cd /xiaoju-survey/server && npm install && npm run build
 
-# 暴露端口 需要跟server的port一致
+# 暴露端口 需要跟nginx的port一致
 # EXPOSE 3000
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,25 @@ WORKDIR /xiaoju-survey
 # 复制文件到工作区间
 COPY . /xiaoju-survey
 
+# 安装nginx
+RUN apt-get update && \
+    apt-get install -y nginx
+
 RUN npm config set registry https://registry.npmjs.org/
 
 # 安装项目依赖
 RUN cd /xiaoju-survey/web && npm install && npm run build
 # 用了后端服务代理启动，建议使用nginx启动
-RUN cd /xiaoju-survey && cp -af ./web/dist/* ./server/public/
+#RUN cd /xiaoju-survey && cp -af ./web/dist/* ./server/public/
+# 覆盖nginx配置文件
+COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 
 RUN cd /xiaoju-survey/server && npm install && npm run build
 
 # 暴露端口 需要跟server的port一致
-EXPOSE 3000
+# EXPOSE 3000
+EXPOSE 8080
 
-# docker入口文件,运行pm2启动,并保证监听不断
+
+# docker入口文件,启动nginx和运行pm2启动,并保证监听不断
 CMD ["sh","docker-run.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     container_name: xiaoju-survey
     restart: always
     ports:
-      - "8080:3000" # API端口
+      - "8080:8080" # API端口
     environment:
       XIAOJU_SURVEY_MONGO_URL: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@xiaoju-survey-mongo:27017 # docker-compose 会根据容器名称自动处理
     links:

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,3 +1,7 @@
 #! /bin/bash 
+
+# 启动nginx
+nginx -g 'daemon on;'
+# 启动后端服务
 cd /xiaoju-survey/server
 npm run start:prod

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,54 @@
+# 启动的 worker 进程数量
+worker_processes  auto;
+
+# 错误日志路径和级别
+error_log  /var/log/nginx/error.log warn;
+
+events {
+  # 最大连接数
+  worker_connections  1024;
+}
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log  /var/log/nginx/access.log  main;
+  sendfile        on;
+  keepalive_timeout  65;
+  server {
+		listen 8080;
+    #  IPv6端口
+    listen  [::]:8080; 
+    server_name  localhost;
+		# gzip config
+		gzip on;
+		gzip_min_length 1k;
+		gzip_comp_level 9;
+		gzip_types text/plain text/css text/javascript application/json application/javascript              application/x-javascript application/xml;
+		gzip_vary on;
+		gzip_disable "MSIE [1-6]\.";
+		root /xiaoju-survey/web/dist;
+
+		location / {
+      try_files $uri $uri /management.html;
+		}
+
+    location /management/ {
+      try_files $uri $uri/ /management.html;
+    }
+
+    location /render/ {
+      try_files $uri $uri/ /render.html;
+    }
+
+    location /api {
+      proxy_pass http://127.0.0.1:3000;
+    }
+    
+    error_page 500 502 503 504 /500.html;
+    client_max_body_size 20M;
+	}
+
+}


### PR DESCRIPTION
1.更改Dockerfile文件
      加入安装nginx 命令RUN apt-get update && \ apt-get install -y nginx
      加入覆盖nginx配置文件的命令COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
      更改暴露的端口号由后端服务的3000端口更改为nginx的8080端口
2.更改docker-run.sh 文件加入启动nginx的命令 nginx -g 'daemon on;'
3.修改docker-compose.yaml 文件将项目将暴露的"8080:3000" 更改为 "8080:8080"
4.在项目根目录新建了一个nginx的文件夹里面创建nginx.conf 用于覆盖默认的nginx配置