### PR TITLE
fix: 修复attrs透传会触发两次select事件

### DIFF
--- a/web/src/management/pages/edit/components/MaterialGroup.vue
+++ b/web/src/management/pages/edit/components/MaterialGroup.vue
@@ -10,7 +10,6 @@
   >
     <template #item="{ element, index }">
       <QuestionWrapper
-        v-bind="$attrs"
         :ref="`questionWrapper-${element.field}`"
         :moduleConfig="element"
         :qIndex="element.qIndex"
@@ -18,15 +17,15 @@
         :isSelected="currentEditOne === index"
         :isLast="index + 1 === questionDataList.length"
         @select="handleSelect"
+        @changeSeq="handleChangeSeq"
       >
         <QuestionContainerB
-          v-bind="$attrs"
           :type="element.type"
           :moduleConfig="element"
           :indexNumber="element.indexNumber"
           :isSelected="currentEditOne === index"
           :readonly="true"
-          @select="handleSelect"
+          @change="handleChange"
         ></QuestionContainerB>
       </QuestionWrapper>
     </template>
@@ -60,9 +59,9 @@ export default defineComponent({
       }
     }
   },
+  emits: ['change', 'select', 'changeSeq'],
   setup(props, { emit }) {
     const store = useStore()
-    
     const renderData = computed({
       get () {
         return filterQuestionPreviewData(props.questionDataList)
@@ -72,7 +71,11 @@ export default defineComponent({
       }
     })
     const handleSelect = (index) => {
+      console.log('materialGroup-handleSelect', index)
       emit('select', index)
+    }
+    const handleChange = (data) => {
+      emit('change', data)
     }
     const handleChangeSeq = (data) => {
       emit('changeSeq', data)
@@ -102,6 +105,7 @@ export default defineComponent({
       DND_GROUP,
       renderData,
       handleSelect,
+      handleChange,
       handleChangeSeq,
       checkMove,
       checkEnd,

--- a/web/src/materials/questions/QuestionContainerB/index.jsx
+++ b/web/src/materials/questions/QuestionContainerB/index.jsx
@@ -75,14 +75,10 @@ export default defineComponent({
     const onChange = (data) => {
       emit('change', data)
     }
-    const onClick = () => {
-      emit('select', props.indexNumber)
-    }
 
     return {
       props,
       BlockComponent,
-      onClick,
       onBlur,
       onFocus,
       onChange,


### PR DESCRIPTION
### 改动内容
修复attrs透传会触发两次select事件

### Issue
[<!-- 确保大的改动创建一个Issue描述详情：https://github.com/didi/xiaoju-survey/issues/new?assignees=&labels=&projects=&template=pr_report.md&title=[类型]: xxx -->](https://github.com/didi/xiaoju-survey/issues/122)