### PR TITLE
fix: 修复问卷编辑页最后一题处于活动状态下删除导致问题

### DIFF
--- a/web/src/management/pages/edit/components/QuestionWrapper.vue
+++ b/web/src/management/pages/edit/components/QuestionWrapper.vue
@@ -118,6 +118,10 @@ const onDelete = async () => {
       type: 'warning'
     })
 
+    if (props.isSelected && props.isLast) {
+      emit('select', null)
+    }
+
     const index = props.qIndex
     emit('changeSeq', { type: 'delete', index })
     isHover.value = false


### PR DESCRIPTION
<!-- 请严格遵循贡献规范：https://xiaojusurvey.didi.cn/docs/next/share/%E8%B4%A1%E7%8C%AE%E6%B5%81%E7%A8%8B -->

### 改动内容
修复问卷编辑页最后一题处于活动状态下删除导致问题
改动文件：
```bash
src/management/pages/edit/components/QuestionWrapper.vue
```

### Issue
 [最后一题活动状态下删除操作会触发两处问题](https://github.com/didi/xiaoju-survey/issues/140)
