### PR TITLE
fix: 修复活动题型选区多次点击重复触发 select 事件 (#154)

### DIFF
--- a/web/src/management/pages/edit/components/MaterialGroup.vue
+++ b/web/src/management/pages/edit/components/MaterialGroup.vue
@@ -63,15 +63,14 @@ export default defineComponent({
   setup(props, { emit }) {
     const store = useStore()
     const renderData = computed({
-      get () {
+      get() {
         return filterQuestionPreviewData(props.questionDataList)
       },
-      set (questionDataList) {
+      set(questionDataList) {
         store.commit('edit/setQuestionDataList', questionDataList)
       }
     })
     const handleSelect = (index) => {
-      console.log('materialGroup-handleSelect', index)
       emit('select', index)
     }
     const handleChange = (data) => {

--- a/web/src/management/pages/edit/components/QuestionWrapper.vue
+++ b/web/src/management/pages/edit/components/QuestionWrapper.vue
@@ -6,7 +6,7 @@
     @click="clickFormItem"
   >
     <div><slot v-if="moduleConfig.type !== 'section'"></slot></div>
-    
+
     <div :class="[showHover ? 'visibily' : 'hidden', 'hoverItem']">
       <div class="item el-icon-rank" @click.stop.prevent="onMove">
         <i-ep-rank />
@@ -88,7 +88,10 @@ const showCopy = computed(() => {
 
 const clickFormItem = () => {
   const index = props.qIndex
-  emit('select', index)
+
+  if (!props.isSelected) {
+    emit('select', index)
+  }
 }
 const onCopy = () => {
   const index = props.qIndex
@@ -115,7 +118,7 @@ const onMoveDown = () => {
   isHover.value = false
 }
 const onDelete = async () => {
-  if(unref(hasShowLogic)) {
+  if (unref(hasShowLogic)) {
     ElMessageBox.alert('该问题被逻辑依赖，请先删除逻辑依赖', '提示', {
       confirmButtonText: '确定',
       type: 'warning'
@@ -193,10 +196,10 @@ const onMove = () => {}
       }
     }
   }
-  .logic-text{
+  .logic-text {
     font-size: 12px;
     color: #c8c9cd;
-    padding: 0 .4rem;
+    padding: 0 0.4rem;
     line-height: 26px;
   }
 }


### PR DESCRIPTION
<!-- 请严格遵循贡献规范：https://xiaojusurvey.didi.cn/docs/next/share/%E8%B4%A1%E7%8C%AE%E6%B5%81%E7%A8%8B -->

### 改动内容
QuestionWrapper.vue 组件

``` ts
const clickFormItem = () => {
  const index = props.qIndex

  if (!props.isSelected) {  // 此处增加代码
    emit('select', index)
  }
}
```

### Issue
#154
