### PR TITLE
refactor: 重构 management/pages/publishResult 目录下组件, 使用 Vue3 组合式 API 写法

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -7,9 +7,14 @@ module.exports = {
     'plugin:vue/vue3-essential',
     'eslint:recommended',
     '@vue/eslint-config-typescript',
-    '@vue/eslint-config-prettier/skip-formatting'
+    '@vue/eslint-config-prettier/skip-formatting',
   ],
+  rules: {
+    "vue/multi-word-component-names": ["error", {
+      "ignores": ["index"]
+    }]
+  },
   parserOptions: {
-    ecmaVersion: 'latest'
-  }
+    ecmaVersion: 'latest',
+  },
 }

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,7 @@
     "@rushstack/eslint-patch": "^1.10.2",
     "@tsconfig/node20": "^20.1.2",
     "@types/node": "^20.11.19",
+    "@types/qrcode": "^1.5.5",
     "@vitejs/plugin-vue": "^5.0.3",
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "@vue/eslint-config-prettier": "^8.0.0",

--- a/web/src/management/components/LeftMenu.vue
+++ b/web/src/management/components/LeftMenu.vue
@@ -25,7 +25,7 @@ const tabs = [
     text: '投放问卷',
     icon: 'icon-toufang',
     to: {
-      name: 'publishResultPage'
+      name: 'publish'
     }
   },
   {

--- a/web/src/management/pages/edit/modules/contentModule/PublishPanel.vue
+++ b/web/src/management/pages/edit/modules/contentModule/PublishPanel.vue
@@ -53,9 +53,7 @@ export default {
         if (publishRes.code === 200) {
           ElMessage.success('发布成功')
           this.$store.dispatch('edit/getSchemaFromRemote')
-          this.$router.push({
-            name: 'publishResultPage'
-          })
+          this.$router.push({ name: 'publish' })
         } else {
           ElMessage.error(`发布失败 ${publishRes.errmsg}`)
         }

--- a/web/src/management/pages/publish/components/ChannelRow.vue
+++ b/web/src/management/pages/publish/components/ChannelRow.vue
@@ -4,63 +4,66 @@
       <div class="left">
         <div class="crc-url-wrap" :class="{ 'no-name': !data.name }">
           <div style="margin-bottom: 16px">
-            <el-input class="cru-content" :model-value="getFullUrl(data)" :readonly="true" />
+            <el-input class="cru-content" :model-value="normalizationURL(data)" :readonly="true" />
           </div>
         </div>
       </div>
       <div class="operate-btn-group">
         <el-tooltip class="item" effect="dark" content="在新页面打开" placement="top">
-          <a class="cru-suffix j-open" @click="openPage(getFullUrl(data))">
+          <a class="cru-suffix j-open" @click="handleOpenPage(normalizationURL(data))">
             <i class="font23 iconfont icon-jinru"></i>
           </a>
         </el-tooltip>
         <el-tooltip class="item" effect="dark" content="复制链接" placement="top">
-          <a class="cru-suffix j-copy" :data-clipboard-text="getFullUrl(data)" @click="handleCopy">
+          <a
+            class="cru-suffix j-copy"
+            :data-clipboard-text="normalizationURL(data)"
+            @click="handleCopy"
+          >
             <i class="font23 iconfont icon-fuzhi"></i>
           </a>
         </el-tooltip>
-        <QRCode class="cru-suffix" :url="getFullUrl(data)" />
+        <QRCode class="cru-suffix" :url="normalizationURL(data)" />
       </div>
     </div>
   </div>
 </template>
 
-<script>
+<script setup lang="ts">
 import Clipboard from 'clipboard'
-
 import { ElMessage } from 'element-plus'
 import 'element-plus/theme-chalk/src/message.scss'
 
 import QRCode from './QRCode.vue'
 
-export default {
-  name: 'ChannelRow',
-  components: {
-    QRCode
-  },
-  props: ['data', 'styleWrap'],
-  methods: {
-    handleCopy() {
-      const clipboard = new Clipboard('.j-copy')
-      clipboard.on('success', (e) => {
-        ElMessage({
-          type: 'success',
-          message: `已复制渠道链接：${e.text}`
-        })
-      })
-    },
-    openPage(url) {
-      window.open(url)
-    },
-    getFullUrl(v) {
-      const url = v.fullUrl
-      const protocol = window.location.protocol
-      return `${protocol}//${url.split('//')[1]}`
-    }
-  }
+interface Props {
+  data: any
+  styleWrap: any
+}
+
+defineProps<Props>()
+
+const handleCopy = () => {
+  const clipboard = new Clipboard('.j-copy')
+  clipboard.on('success', (e) => {
+    ElMessage({
+      type: 'success',
+      message: `已复制渠道链接：${e.text}`
+    })
+
+    clipboard.destroy()
+  })
+}
+
+const handleOpenPage = (url: string) => window.open(url)
+
+const normalizationURL = (value: any) => {
+  const url = value.fullUrl
+  const protocol = window.location.protocol
+
+  return `${protocol}//${url.split('//')[1]}`
 }
 </script>
-
 <style lang="scss" scoped>
 .channel-list-wrap div.normal-row-wrap {
   position: relative;

--- a/web/src/management/pages/publish/components/QRCode.vue
+++ b/web/src/management/pages/publish/components/QRCode.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="qrcode" @mouseover="inQcode = true" @mouseout="inQcode = false">
+  <div class="qrcode">
     <div class="qcode-mask">
       <el-popover
         ref="popover"
@@ -18,42 +18,42 @@
   </div>
 </template>
 
-<script>
+<script setup lang="ts">
+import { ref, watch, computed, nextTick } from 'vue'
+
 import QRCode from 'qrcode'
 
-export default {
-  name: 'QRCode',
-  props: ['url'],
-  data() {
-    return {
-      inQcode: false,
-      qRCodeImg: ''
-    }
-  },
-  methods: {
-    initQRCodeImg() {
-      QRCode.toDataURL(this.url)
-        .then((url) => {
-          this.qRCodeImg = url
-        })
-        .catch((err) => {
-          console.error(err)
-        })
-    }
-  },
-  watch: {
-    url: {
-      immediate: true,
-      handler(newVal) {
-        if (newVal) {
-          this.$nextTick(() => {
-            this.initQRCodeImg()
-          })
-        }
-      }
-    }
+interface Props {
+  url: string
+}
+
+const props = defineProps<Props>()
+
+const qRCodeImg = ref<string>('')
+const watchURL = computed<string>(() => props.url)
+
+const convertUrlToQRCode = async (url: string) => {
+  try {
+    const res = await QRCode.toDataURL(url)
+    qRCodeImg.value = res
+  } catch (err) {
+    console.log(err)
   }
 }
+
+watch(
+  watchURL,
+  (value) => {
+    if ((!qRCodeImg.value && value) || watchURL.value !== value) {
+      nextTick(() => {
+        convertUrlToQRCode(value)
+      })
+    }
+  },
+  {
+    immediate: true
+  }
+)
 </script>
 
 <style lang="scss" scoped>

--- a/web/src/management/router/index.ts
+++ b/web/src/management/router/index.ts
@@ -94,12 +94,12 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../pages/analysis/AnalysisPage.vue')
   },
   {
-    path: '/survey/:id/publishResult',
-    name: 'publishResultPage',
+    path: '/survey/:id/publish',
+    name: 'publish',
     meta: {
       needLogin: true
     },
-    component: () => import('../pages/publishResult/PublishResultPage.vue')
+    component: () => import('../pages/publish/index.vue')
   },
   {
     path: '/create',


### PR DESCRIPTION
### 改动内容
使用 Vue3 组合式 API 写法对 management/pages/publishResult 目录列表文件进行调整

```bash
management/pages/publishResult
├── PublishResultPage.vue
└── components
    ├── ChannelRow.vue
    └── QRCode.vue
```