### PR TITLE
fix: 修复物料设置组件 RangeSetter 在设置最大值与最小值引发问题

### DIFF
--- a/web/src/materials/setters/widgets/RangeSetter.vue
+++ b/web/src/materials/setters/widgets/RangeSetter.vue
@@ -56,8 +56,8 @@ const maxModelValue = computed(() => {
 
 const handleRangeChange = (eventType: 'max' | 'min', value: number) => {
   const key = props.formConfig.key
-  const initMinValue = props.formConfig.value.min.value
-  const initMaxValue = props.formConfig.value.max.value
+  const initMinValue = minModelValue.value
+  const initMaxValue = maxModelValue.value
 
   if (
     (eventType === 'max' && value < initMinValue) ||


### PR DESCRIPTION
### Issue
#174 
