### PR TITLE
feat: 增加接口数据缓存以及修复attrs问题

### DIFF
--- a/web/src/management/api/space.ts
+++ b/web/src/management/api/space.ts
@@ -1,4 +1,5 @@
 import axios from './base'
+import memorize from '../utils/memorize'
 
 // 空间
 export const createSpace = ({ name, description, members }: any) => {
@@ -73,3 +74,4 @@ export const getCollaboratorPermissions = (surveyId: string) => {
     }
   })
 }
+export const getCollaboratorPermissionsMemorize = memorize(getCollaboratorPermissions)

--- a/web/src/management/api/space.ts
+++ b/web/src/management/api/space.ts
@@ -30,10 +30,12 @@ export const getUserList = (username: string) => {
   })
 }
 
-// 协作权限列表
+// 获取协作权限下拉框枚举
 export const getPermissionList = () => {
   return axios.get('collaborator/getPermissionList')
 }
+// 因为协作权限列表枚举相对固定，所以使用memorize缓存一下，减少请求次数
+export const getPermissionListMemorize = memorize(getPermissionList)
 
 export const saveCollaborator = ({ surveyId, collaborators }: any) => {
   return axios.post('collaborator/batchSave', {
@@ -74,4 +76,3 @@ export const getCollaboratorPermissions = (surveyId: string) => {
     }
   })
 }
-export const getCollaboratorPermissionsMemorize = memorize(getCollaboratorPermissions)

--- a/web/src/management/components/LeftMenu.vue
+++ b/web/src/management/components/LeftMenu.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute } from 'vue-router'
 const route = useRoute()
@@ -58,18 +58,17 @@ const tabArr = [
   }
 ]
 const tabs = ref([])
-onMounted(async () => {
-  await store.dispatch('fetchCooperPermissions', route.params.id)
+watch(() => store.state.cooperPermissions, (newVal) => {
   // 如果有问卷管理权限，则加入问卷编辑和投放菜单
-  if (store.state.cooperPermissions.includes(SurveyPermissions.SurveyManage)) {
+  if (newVal.includes(SurveyPermissions.SurveyManage)) {
     tabs.value.push(tabArr[0])
     tabs.value.push(tabArr[1])
-  }
+  } 
   // 如果有数据分析权限，则加入数据分析菜单
-  if (store.state.cooperPermissions.includes(SurveyPermissions.DataManage)) {
+  if (newVal.includes(SurveyPermissions.DataManage))  {
     tabs.value.push(tabArr[2])
   }
-})
+}, { immediate: true })
 </script>
 <style lang="scss" scoped>
 .nav {

--- a/web/src/management/pages/list/components/CooperModify.vue
+++ b/web/src/management/pages/list/components/CooperModify.vue
@@ -44,7 +44,7 @@ import { computed, ref, shallowRef, onMounted, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import 'element-plus/theme-chalk/src/message.scss'
 import MemberSelect from './MemberSelect.vue'
-import { getPermissionList, getCollaborator, saveCollaborator } from '@/management/api/space'
+import { getPermissionListMemorize, getCollaborator, saveCollaborator } from '@/management/api/space'
 import { type IMember, SurveyPermissions } from '@/management/utils/types/workSpace'
 import { CODE_MAP } from '@/management/api/base'
 const emit = defineEmits(['on-close-codify', 'onFocus', 'change', 'blur'])
@@ -64,7 +64,7 @@ const formTitle = ref('协作管理')
 
 const cooperOptions = ref([])
 onMounted(async () => {
-  const res: any = await getPermissionList()
+  const res: any = await getPermissionListMemorize()
   if (res.code === CODE_MAP.SUCCESS) {
     cooperOptions.value = res.data.map((item: any) => {
       return {

--- a/web/src/management/pages/list/components/SpaceList.vue
+++ b/web/src/management/pages/list/components/SpaceList.vue
@@ -10,7 +10,6 @@
       row-class-name="tableview-row"
       cell-class-name="tableview-cell"
       style="width: 100%"
-      @row-click="onRowClick"
     >
       <el-table-column column-key="space" width="20" />
       <el-table-column
@@ -98,9 +97,7 @@ const isAdmin = (id: string) => {
     UserRole.Admin
   )
 }
-const onRowClick = () => {
-  console.log('onRowClick')
-}
+
 const handleModify = async (id: string) => {
   await store.dispatch('list/getSpaceDetail', id)
   modifyType.value = 'edit'

--- a/web/src/management/store/actions.js
+++ b/web/src/management/store/actions.js
@@ -1,5 +1,5 @@
 import { getBannerData } from '@/management/api/skin.js'
-import { getCollaboratorPermissionsMemorize } from '@/management/api/space.ts'
+import { getCollaboratorPermissions } from '@/management/api/space.ts'
 import { CODE_MAP } from '../api/base'
 
 export default {

--- a/web/src/management/store/actions.js
+++ b/web/src/management/store/actions.js
@@ -1,5 +1,5 @@
 import { getBannerData } from '@/management/api/skin.js'
-import { getCollaboratorPermissions } from '@/management/api/space.ts'
+import { getCollaboratorPermissionsMemorize } from '@/management/api/space.ts'
 import { CODE_MAP } from '../api/base'
 
 export default {
@@ -13,7 +13,7 @@ export default {
     }
   },
   async fetchCooperPermissions({ commit }, id) {
-    const res = await getCollaboratorPermissions(id)
+    const res = await getCollaboratorPermissionsMemorize(id)
     console.log(res.data)
     if (res.code === CODE_MAP.SUCCESS) {
       commit('setCooperPermissions', res.data.permissions)

--- a/web/src/management/store/actions.js
+++ b/web/src/management/store/actions.js
@@ -13,7 +13,7 @@ export default {
     }
   },
   async fetchCooperPermissions({ commit }, id) {
-    const res = await getCollaboratorPermissionsMemorize(id)
+    const res = await getCollaboratorPermissions(id)
     if (res.code === CODE_MAP.SUCCESS) {
       commit('setCooperPermissions', res.data.permissions)
     }

--- a/web/src/management/store/actions.js
+++ b/web/src/management/store/actions.js
@@ -14,7 +14,6 @@ export default {
   },
   async fetchCooperPermissions({ commit }, id) {
     const res = await getCollaboratorPermissionsMemorize(id)
-    console.log(res.data)
     if (res.code === CODE_MAP.SUCCESS) {
       commit('setCooperPermissions', res.data.permissions)
     }

--- a/web/src/management/utils/memorize.ts
+++ b/web/src/management/utils/memorize.ts
@@ -1,0 +1,35 @@
+const serialize = (obj: any): string => {
+  if (obj == null) {
+    return ''
+  } else if (Array.isArray(obj)) {
+    const items = obj.map((item) => serialize(item))
+    return `[${items.join(',')}]`
+  } else if (isPlainObject(obj)) {
+    const keys = Object.keys(obj)
+    keys.sort()
+    const items = keys.map((key) => `${key}=${serialize(obj[key])}`)
+    return `{${items.join('&')}}`
+  } else if (typeof obj === 'object' && typeof obj.valueOf === 'function') {
+    return serialize(obj.valueOf())
+  } else {
+    return obj + ''
+  }
+}
+
+function isPlainObject(obj: Object) {
+  const prototype = Object.getPrototypeOf(obj)
+  return obj && typeof obj === 'object' && (prototype === null || prototype === Object.prototype)
+}
+
+export default function memorize(fn: Function) {
+  const results: any = {}
+
+  return (...args: any) => {
+    const key = serialize(args)
+    if (!(key in results)) {
+      // @ts-ignore
+      results[key] = fn.apply(this, args)
+    }
+    return results[key]
+  }
+}

--- a/web/src/materials/questions/widgets/EditOptions/Options/OptionEditBar.vue
+++ b/web/src/materials/questions/widgets/EditOptions/Options/OptionEditBar.vue
@@ -78,7 +78,6 @@ const emit = defineEmits(['addOther', 'optionChange', 'change'])
 const moduleConfig = inject('moduleConfig')
 const optionConfigVisible = ref(false)
 const openOptionConfig = () => {
-  console.log('open')
   optionConfigVisible.value = true
 }
 

--- a/web/src/render/components/MaterialGroup.vue
+++ b/web/src/render/components/MaterialGroup.vue
@@ -3,11 +3,8 @@
     <div v-for="item in renderData" :key="item.field">
       <QuestionWrapper
         class="gap"
-        v-bind="$attrs"
         :moduleConfig="item"
-        :qIndex="item.qIndex"
         :indexNumber="item.indexNumber"
-        :showTitle="true"
         @change="handleChange"
       ></QuestionWrapper>
     </div>

--- a/web/src/render/components/QuestionWrapper.vue
+++ b/web/src/render/components/QuestionWrapper.vue
@@ -1,7 +1,6 @@
 <template>
   <QuestionRuleContainer
     v-if="visible"
-    v-bind="$attrs"
     :moduleConfig="questionConfig"
     :indexNumber="indexNumber"
     :showTitle="true"

--- a/web/src/render/pages/IndexPage.vue
+++ b/web/src/render/pages/IndexPage.vue
@@ -98,7 +98,6 @@ const normalizationRequestBody = () => {
 const submitSurver = async () => {
   try {
     const params = normalizationRequestBody()
-    console.log(params)
     const res: any = await submitForm(params)
     if (res.code === 200) {
       store.commit('setRouter', 'successPage')

--- a/web/src/render/store/getters.js
+++ b/web/src/render/store/getters.js
@@ -10,7 +10,6 @@ export default {
         const questionArr = []
 
         item.forEach((questionKey) => {
-          console.log('题目重新计算')
           const question = { ...questionData[questionKey] }
           // 开启显示序号
           if (question.showIndex) {


### PR DESCRIPTION
### 改动内容
1. 协作列表的权限下拉框数据相对固定，所以使用memorize缓存一下，减少请求次数
2. 编辑页左侧的菜单监听权限数据，填充相应权限的菜单，避免编辑页重复发起权限请求
3. 去掉使用不到的attrs透传