### PR TITLE
feat: c端路由改造

### DIFF
--- a/web/src/management/router/index.ts
+++ b/web/src/management/router/index.ts
@@ -171,18 +171,4 @@ router.beforeEach(async (to, from, next) => {
     next()
   }
 })
-
-// router.afterEach(async (to, from) => {
-//   const store = useStore()
-//   if (to.meta.premissions) {
-//     const params = to.params
-//     await store.dispatch('fetchCooperPermissions', params.id)
-//     if (!(to.meta.premissions as []).some((permission) => store.state?.cooperPermissions?.includes(permission))) {
-//       ElMessage.warning('您没有该问卷的相关协作权限')
-//       router.push({
-//         name: 'survey'
-//       })
-//     }
-//   }
-// })
 export default router

--- a/web/src/render/main.js
+++ b/web/src/render/main.js
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import EventBus from './utils/eventbus'
-
+import router from './router'
 import store from './store'
 
 const app = createApp(App)
@@ -10,7 +10,7 @@ const $bus = new EventBus()
 app.provide('$bus', $bus)
 // 挂载到this上
 app.config.globalProperties.$bus = $bus
-
+app.use(router)
 app.use(store)
 
 app.mount('#app')

--- a/web/src/render/pages/ErrorPage.vue
+++ b/web/src/render/pages/ErrorPage.vue
@@ -1,16 +1,21 @@
 <template>
   <div class="result-page-wrap">
     <div class="result-page">
-      <div class="error-wrapper">
-        <img class="error-img" :src="errorImageUrl" />
-        <div class="bottom-word" v-html="errorMsg"></div>
+      <div class="page-content">
+        <img class="img" :src="errorImageUrl" />
+        <div class="msg" v-html="errorMsg"></div>
       </div>
+      <LogoIcon :logo-conf="logoConf" :readonly="true" />
     </div>
   </div>
 </template>
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useStore } from 'vuex'
+// @ts-ignore
+import communalLoader from '@materials/communals/communalLoader.js'
+
+const LogoIcon = communalLoader.loadComponent('LogoIcon')
 
 const store = useStore()
 
@@ -24,7 +29,8 @@ const errorImageUrl = computed(() => {
   return imageMap[errorType as 'overTime'] || imageMap.default
 })
 
-const errorMsg = computed(() => store.state?.errorInfo?.errorMsg)
+const errorMsg = computed(() => store.state?.errorInfo?.errorMsg || '提交失败')
+const logoConf = computed(() => store.state?.bottomConf || {})
 </script>
 <style lang="scss" scoped>
 .result-page-wrap {
@@ -42,25 +48,27 @@ const errorMsg = computed(() => store.state?.errorInfo?.errorMsg)
     height: 100%;
   }
 }
-.error-wrapper {
-  text-align: center;
-  font-size: 14px;
+.page-content {
+  position: relative;
+  max-width: 920px;
+  margin: 0 auto;
+  height: 100%;
+  width: 100%;
+  position: relative;
+  padding-top: 2rem;
   flex: 1;
 
-  p {
-    text-align: center;
-  }
-
-  .error-img {
-    margin-top: 2rem;
-    margin-bottom: 30px;
+  .img {
     width: 2rem;
-    height: auto;
   }
 
-  .bottom-word {
-    color: #999;
-    margin-top: 10px;
+  .msg {
+    font-size: 0.32rem;
+    color: #4a4c5b;
+    letter-spacing: 0;
+    text-align: center;
+    font-weight: 500;
+    margin-top: 0.15rem;
   }
 }
 </style>

--- a/web/src/render/pages/IndexPage.vue
+++ b/web/src/render/pages/IndexPage.vue
@@ -21,6 +21,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
 // @ts-ignore
 import communalLoader from '@materials/communals/communalLoader.js'
 import MainRenderer from '../components/MainRenderer.vue'
@@ -55,6 +56,7 @@ const alert = useCommandComponent(AlertDialog)
 const confirm = useCommandComponent(ConfirmDialog)
 
 const store = useStore()
+const router = useRouter()
 
 const bannerConf = computed(() => store.state?.bannerConf || {})
 const renderData = computed(() => store.getters.renderData)
@@ -101,7 +103,8 @@ const submitSurver = async () => {
     console.log(params)
     const res: any = await submitForm(params)
     if (res.code === 200) {
-      store.commit('setRouter', 'successPage')
+      // store.commit('setRouter', 'successPage')
+      router.push({name: 'successPage'})
     } else {
       alert({
         title: res.errmsg || '提交失败'

--- a/web/src/render/router/index.ts
+++ b/web/src/render/router/index.ts
@@ -1,0 +1,35 @@
+import { createRouter, createWebHistory, type  RouteRecordRaw } from 'vue-router'
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: '/render/:surveyId',
+    children: [
+      {
+        path: '',
+        name: 'indexPage',
+        component: () => import('../pages/IndexPage.vue'),
+      },
+      {
+        path: 'success',
+        name: 'successPage',
+        component: () => import('../pages/SuccessPage.vue')
+      },
+      {
+        path: 'error',
+        name: 'errorPage',
+        component: () => import('../pages/ErrorPage.vue')
+      }
+    ]
+  },
+  {
+    path: '/:catchAll(.*)',
+    name: 'emptyPage',
+    component: () => import('../pages/EmptyPage.vue')
+  }
+]
+
+const router = createRouter({
+  history: createWebHistory('/management'),
+  routes
+})
+export default router

--- a/web/src/render/store/actions.js
+++ b/web/src/render/store/actions.js
@@ -3,6 +3,7 @@ import moment from 'moment'
 import 'moment/locale/zh-cn'
 // 设置中文
 moment.locale('zh-cn')
+// import { useRouter } from 'vue-router'
 import adapter from '../adapter'
 import { queryVote, getEncryptInfo } from '@/render/api/survey'
 import { RuleMatch } from '@/common/logicEngine/RulesMatch'
@@ -15,16 +16,19 @@ const CODE_MAP = {
   NO_AUTH: 403
 }
 const VOTE_INFO_KEY = 'voteinfo'
-
+// const router = useRouter() || {push: ()=> {}}
+import router from '../router'
+console.log({ router })
 export default {
   // 初始化
-  init({ commit, dispatch }, { bannerConf, baseConf, bottomConf, dataConf, skinConf, submitConf }) {
+  init({ state, commit, dispatch }, { bannerConf, baseConf, bottomConf, dataConf, skinConf, submitConf }) {
     commit('setEnterTime')
     const { begTime, endTime, answerBegTime, answerEndTime } = baseConf
     const { msgContent } = submitConf
     const now = Date.now()
     if (now < new Date(begTime).getTime()) {
-      commit('setRouter', 'errorPage')
+      // commit('setRouter', 'errorPage')
+      router.push({ name: 'errorPage'})
       commit('setErrorInfo', {
         errorType: 'overTime',
         errorMsg: `<p>问卷未到开始填写时间，暂时无法进行填写<p/>
@@ -32,7 +36,8 @@ export default {
       })
       return
     } else if (now > new Date(endTime).getTime()) {
-      commit('setRouter', 'errorPage')
+      // commit('setRouter', 'errorPage')
+      router.push({ name: 'errorPage'})
       commit('setErrorInfo', {
         errorType: 'overTime',
         errorMsg: msgContent.msg_9001 || '您来晚了，感谢支持问卷~'
@@ -44,7 +49,8 @@ export default {
       const momentStartTime = moment(`${todayStr} ${answerBegTime}`)
       const momentEndTime = moment(`${todayStr} ${answerEndTime}`)
       if (momentNow.isBefore(momentStartTime) || momentNow.isAfter(momentEndTime)) {
-        commit('setRouter', 'errorPage')
+        // commit('setRouter', 'errorPage')
+        router.push({ name: 'errorPage'})
         commit('setErrorInfo', {
           errorType: 'overTime',
           errorMsg: `<p>不在答题时间范围内，暂时无法进行填写<p/>
@@ -53,7 +59,9 @@ export default {
         return
       }
     }
-    commit('setRouter', 'indexPage')
+    // commit('setRouter', 'indexPage')
+    const surveyPath = state.surveyPath
+    router.push({ name: 'indexPage', params: {surveyId: surveyPath} })
 
     // 根据初始的schema生成questionData, questionSeq, rules, formValues, 这四个字段
     const { questionData, questionSeq, rules, formValues } = adapter.generateData({


### PR DESCRIPTION
### 改动内容
异步组件改为router页面
1. 新建router表
2. main引入router
3. app.vue中异步组件改为<router-view></router-view>
4. 异步组件切换改为路由跳转，即commit('setRouter', 'errorPage')，改为router.push({ name: 'errorPage'})形式
5. 使用router后，在结果页刷新页面需要重定向到提交页
6. 统一errorpage页面的dom结构样式和successPage保持一致