### PR TITLE
[refactor]: check for the ispc-html class is done using a regular expression to ensure that the class is only added once when the browser window is resized

### DIFF
--- a/web/src/render/index.html
+++ b/web/src/render/index.html
@@ -15,7 +15,9 @@
 
           if (!/Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent)) {
             width = width < PC_W ? width : PC_W
-            docEl.className += ' ispc-html'
+            if (!docEl.className.includes('ispc-html')) {
+              docEl.className += ' ispc-html'
+            }
           }
 
           var f = Math.min(width / 7.5, 50)


### PR DESCRIPTION
### 问题
pc端填写问卷页面浏览器resize后 html标签会有多个ispc-html类名

### 改动内容
1.pc端填写问卷页面浏览器resize后 html标签只保留一个 ispc-html类名

### Issue
https://github.com/didi/xiaoju-survey/issues/299
