### PR TITLE
feat: 物料脱离store依赖

### DIFF
--- a/web/src/materials/questions/QuestionContainerB/index.jsx
+++ b/web/src/materials/questions/QuestionContainerB/index.jsx
@@ -109,13 +109,13 @@ export default defineComponent({
             <EditOptions
               moduleConfig={props.moduleConfig}
               editConfigure={questionMeta?.editConfigure}
+              onChange={this.onChange}
             >
               <dynamicComponent
                 readonly
                 {...props}
                 onBlur={this.onBlur}
                 onFocus={this.onFocus}
-                change={this.onChange}
               />
             </EditOptions>
           ) : (
@@ -124,7 +124,6 @@ export default defineComponent({
               {...props}
               onBlur={this.onBlur}
               onFocus={this.onFocus}
-              change={this.onChange}
             />
           )}
         </div>

--- a/web/src/materials/questions/widgets/EditOptions/AdvancedConfig/RateConfig.vue
+++ b/web/src/materials/questions/widgets/EditOptions/AdvancedConfig/RateConfig.vue
@@ -43,7 +43,6 @@
 </template>
 <script>
 import { get as _get } from 'lodash-es'
-import { mapGetters } from 'vuex'
 export default {
   props: {
     min: {
@@ -80,9 +79,6 @@ export default {
     this.initRange()
   },
   computed: {
-    ...mapGetters({
-      currentEditKey: 'edit/currentEditKey'
-    }),
     innerVisible: {
       get() {
         return this.visible
@@ -119,9 +115,8 @@ export default {
           explain: item.explain
         }
       }
-      const paramsKey = `rangeConfig`
       const payload = {
-        key: `${this.currentEditKey}.${paramsKey}`,
+        key: `rangeConfig`,
         value: res
       }
       this.$emit('confirm', payload)

--- a/web/src/materials/questions/widgets/EditOptions/Options/OptionEdit.vue
+++ b/web/src/materials/questions/widgets/EditOptions/Options/OptionEdit.vue
@@ -39,17 +39,11 @@
 
 <script>
 import draggable from 'vuedraggable'
-import { mapGetters } from 'vuex'
 import { cloneDeep as _cloneDeep } from 'lodash-es'
 import RichEditor from '@/common/Editor/RichEditor.vue'
 
 export default {
   name: 'OptionEdit',
-  computed: {
-    ...mapGetters({
-      currentEditKey: 'edit/currentEditKey'
-    })
-  },
   props: {
     optionList: {
       type: Array
@@ -92,7 +86,7 @@ export default {
     handleChange(index, value) {
       // 更新单个选项文案
       const optionKey = `options[${index}].text`
-      const key = `${this.currentEditKey}.${optionKey}`
+      const key = `${optionKey}`
       this.$emit('change', { key, value })
     },
     onAddOption(index) {

--- a/web/src/materials/questions/widgets/EditOptions/index.jsx
+++ b/web/src/materials/questions/widgets/EditOptions/index.jsx
@@ -1,7 +1,5 @@
 import { defineComponent, ref, computed, onMounted } from 'vue'
 
-import store from '@/management/store'
-
 import OptionEdit from './Options/OptionEdit.vue'
 import OptionEditBar from './Options/OptionEditBar.vue'
 import UseOptionBase from './Options/UseOptionBase'
@@ -10,7 +8,6 @@ export default defineComponent({
   name: 'EditOptions',
   provide() {
     return {
-      currentEditKey: store.getters['edit/currentEditKey'],
       moduleConfig: computed(() => this.moduleConfig)
     }
   },
@@ -24,10 +21,7 @@ export default defineComponent({
       required: true
     }
   },
-  setup(props, { slots }) {
-    const currentEditKey = computed(() => {
-      return store.getters['edit/currentEditKey']
-    })
+  setup(props, { slots, emit }) {
     const getOptions = computed(() => {
       return props.moduleConfig.options
     })
@@ -44,12 +38,12 @@ export default defineComponent({
 
     const handleOptionChange = (value) => {
       const optionKey = `options`
-      const key = `${currentEditKey.value}.${optionKey}`
+      const key = `${optionKey}`
       handleChange({ key, value })
     }
 
     const handleChange = ({ key, value }) => {
-      store.dispatch('edit/changeSchema', { key, value })
+      emit('change', { key, value })
     }
 
     const hasAdvancedConfig = ref(false)


### PR DESCRIPTION
### 改动内容
1. 调整组件传参，从搭建端传递chage事件
2. 编辑态的设置触发搭建端传递的change事件，不直接在物料的编辑态触发store的changeSchema方法