### PR TITLE
fix: 🐛 修复引入 import lodash cloneDeep debounce 错误 改为 lodash-es 了

### DIFF
--- a/web/src/management/hooks/useResizeObserver.js
+++ b/web/src/management/hooks/useResizeObserver.js
@@ -1,5 +1,5 @@
 // 引入防抖函数
-import _debounce from 'lodash/debounce'
+import { debounce as _debounce } from 'lodash-es'
 /**
  * @description: 监听元素尺寸变化
  * @param {*} el 元素dom

--- a/web/src/management/pages/analysis/components/StatisticsItem.vue
+++ b/web/src/management/pages/analysis/components/StatisticsItem.vue
@@ -34,7 +34,7 @@
 
 <script setup>
 import { reactive, toRefs, computed, watch, onMounted, onUnmounted, ref } from 'vue'
-import _cloneDeep from 'lodash/cloneDeep'
+import { cloneDeep as _cloneDeep } from 'lodash-es'
 import {
   separateItemListHead,
   summaryType,


### PR DESCRIPTION
<!-- 请严格遵循贡献规范：https://xiaojusurvey.didi.cn/docs/next/share/%E8%B4%A1%E7%8C%AE%E6%B5%81%E7%A8%8B -->

### 改动内容
<!-- 不同功能拆分成多个PR。简洁记录改动内容，用1、2、3...分序号描述改动点 -->

数据统计 - 分题统计

修复引入 import lodash cloneDeep debounce 错误 改为 lodash-es 了。

<img width="1239" alt="image" src="https://github.com/didi/xiaoju-survey/assets/15962539/93539ad3-f8a9-486d-8f7a-5239ab1444c4">
<img width="1064" alt="image" src="https://github.com/didi/xiaoju-survey/assets/15962539/383f7e5c-a4b1-49f9-b57b-f92c27e8c6f6">


<img width="1059" alt="image" src="https://github.com/didi/xiaoju-survey/assets/15962539/4f91df9e-3fc3-4477-bd0e-1366c364d387">



早在三个月前 `lodash` 依赖就改成了 [fix: 升级lodash-es](https://github.com/didi/xiaoju-survey/pull/73)
分题统计代码是6月21新增的。
>[2024-06-21 16:33 +0800 hiStephen I feat: 分题统计前端开发 (#276)](https://github.com/didi/xiaoju-survey/pull/276)

可能开发时没有重新安装更新依赖，或者用的 `npm`，有幽灵依赖。所以本地开发没有报错。