### PR TITLE
fix: 修复生产环境的c端页面访问空白

### DIFF
--- a/web/src/render/adapter/question.js
+++ b/web/src/render/adapter/question.js
@@ -2,7 +2,17 @@
  * 处理单题的配置
  */
 
-import { get as _get } from 'lodash-es'
+import { get as _get, map as _map } from 'lodash-es'
+// 处理选择题的options
+function handleOptions(item) {
+  const options = item.options || []
+
+  const arr = _map(options, (optionItem) => {
+    return { ...optionItem }
+  })
+
+  return { options: arr }
+}
 
 export default function (questionConfig) {
   let dataList = _get(questionConfig, 'dataConf.dataList')
@@ -12,7 +22,8 @@ export default function (questionConfig) {
       [item.field]: {
         indexNumber: '',
         voteTotal: 0,
-        ...item
+        ...item,
+        ...handleOptions(item)
       }
     })
     return pre


### PR DESCRIPTION
问题表现：开发环境启动运行正常，生产环境c端页面访问空白
复现路径：项目编译部署后，c端页面访问空白
修复方案：把之前删除的handleOption函数加回来后，本地运行build，重启nginx服务后，c端页面方案正常
