### PR TITLE
[Fix]: 修复 dev 配置文件中 MongoDB 重复配置项导致的启动失败问题

### DIFF
--- a/survey-server/src/main/resources/application-dev.properties
+++ b/survey-server/src/main/resources/application-dev.properties
@@ -1,8 +1,5 @@
 server.port=8080
 
-spring.data.mongodb.uri=
-#spring.data.mongodb.database=
-
 spring.data.mongodb.host=localhost
 spring.data.mongodb.port=27017
 spring.data.mongodb.database=testdb


### PR DESCRIPTION
1. 修复 dev 配置文件中 MongoDB 相关的 `spring.data.mongodb.uri` 配置项为空导致覆盖掉已配置好的 `host`, `port`, `database` 等配置从而出现启动失败的问题

