### PR TITLE
处理java端用户体系和node逻辑保持一致

### DIFF
--- a/survey-common/src/main/java/com/xiaojusurvey/engine/common/constants/RespErrorCode.java
+++ b/survey-common/src/main/java/com/xiaojusurvey/engine/common/constants/RespErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum RespErrorCode {
     AUTHENTICATION_FAILED(1001, "没有权限"),
     PARAMETER_ERROR(1002, "参数有误"),
+    ENCRYPTION_ERROR(1003, "加密异常"),
     USER_EXISTS(2001, "用户已存在"),
     USER_NOT_EXISTS(2002, "用户不存在"),
     USER_PASSWORD_ERROR(2003, "用户名或密码错误"),

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/impl/AuthServiceImpl.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/impl/AuthServiceImpl.java
@@ -61,7 +61,7 @@ public class AuthServiceImpl implements AuthService {
         //保存
         User user = new User();
         user.setUsername(userParam.getUsername());
-        user.setPassword(AuthUtil.encryptPassword(userParam.getPassword(), userParam.getUsername()));
+        user.setPassword(AuthUtil.hash256(userParam.getPassword()));
         mongoRepository.save(user);
         return createTokenAndDeleteCaptcha(userParam);
     }

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/util/AuthUtil.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/util/AuthUtil.java
@@ -31,5 +31,30 @@ public class AuthUtil {
         }
     }
 
+    /**
+     * SHA-256
+     * @param password
+     * @return
+     */
+    public static String hash256(String password) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(password.getBytes());
+            // 将 byte 数组转换为十六进制字符串
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
 
 }

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/util/AuthUtil.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/util/AuthUtil.java
@@ -1,6 +1,9 @@
 package com.xiaojusurvey.engine.core.auth.util;
 
 
+import com.xiaojusurvey.engine.common.constants.RespErrorCode;
+import com.xiaojusurvey.engine.common.exception.ServiceException;
+
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -51,8 +54,7 @@ public class AuthUtil {
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-            return null;
+            throw new ServiceException(RespErrorCode.ENCRYPTION_ERROR.getMessage(), RespErrorCode.ENCRYPTION_ERROR.getCode());
         }
     }
 

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/util/JwtTokenUtil.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/util/JwtTokenUtil.java
@@ -59,7 +59,7 @@ public class JwtTokenUtil {
         Date expiryDate = new Date(now.getTime() + expirationTime * HOUR_MILLISECOND);
         String token = JWT.create()
                 .withClaim("username", user.getUsername())
-                .withClaim("password", user.getPassword())
+                .withClaim("_id", user.getId())
                 .withExpiresAt(expiryDate)
                 .withJWTId(UUID.randomUUID().toString())
                 .sign(Algorithm.HMAC256(secret));

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/user/UserService.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/user/UserService.java
@@ -9,4 +9,6 @@ public interface UserService {
     List<User> findAllUser();
 
     User loadUserByUsernameAndPassword(String username, String password);
+
+    User getUserById(String userId);
 }

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/user/impl/UserServiceImpl.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/user/impl/UserServiceImpl.java
@@ -35,7 +35,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public User loadUserByUsernameAndPassword(String username, String password) {
         Query query = new Query();
-        String encryptPassword = AuthUtil.encryptPassword(password, username);
+        String encryptPassword = AuthUtil.hash256(password);
         query.addCriteria(Criteria.where("username").is(username).and("password").is(encryptPassword));
         //查询用户并返回
         User user = mongoRepository.findOne(query, User.class);
@@ -43,5 +43,10 @@ public class UserServiceImpl implements UserService {
             throw new ServiceException(RespErrorCode.USER_PASSWORD_ERROR.getMessage(), RespErrorCode.USER_PASSWORD_ERROR.getCode());
         }
         return user;
+    }
+
+    @Override
+    public User getUserById(String userId) {
+        return mongoRepository.findOne(new Query(Criteria.where("_id").is(userId)), User.class);
     }
 }

--- a/survey-server/src/main/java/com/xiaojusurvey/engine/interceptor/LoginInterceptor.java
+++ b/survey-server/src/main/java/com/xiaojusurvey/engine/interceptor/LoginInterceptor.java
@@ -17,8 +17,12 @@ import java.util.Map;
 
 public class LoginInterceptor implements HandlerInterceptor {
 
+    public static final String USERNAME = "username";
+    public static final String _ID = "_id";
+
     @Resource
     private JwtTokenUtil jwtTokenUtil;
+
     @Resource
     private UserService userService;
 
@@ -39,8 +43,13 @@ public class LoginInterceptor implements HandlerInterceptor {
         //查询用户信息
         Map<String, Claim> claims = jwt.getClaims();
         //获取用户名,密码
-        String username = String.valueOf(claims.get("username"));
-        String userId = String.valueOf(claims.get("_id"));
+        String username = null, userId = null;
+        if (!ObjectUtils.isEmpty(claims.get(USERNAME))) {
+            username = claims.get(USERNAME).asString();
+        }
+        if (!ObjectUtils.isEmpty(claims.get(_ID))) {
+            userId = claims.get(_ID).asString();
+        }
         //判空
         if (ObjectUtils.isEmpty(username) || ObjectUtils.isEmpty(userId)) {
             //token超时

--- a/survey-server/src/main/java/com/xiaojusurvey/engine/interceptor/LoginInterceptor.java
+++ b/survey-server/src/main/java/com/xiaojusurvey/engine/interceptor/LoginInterceptor.java
@@ -17,8 +17,8 @@ import java.util.Map;
 
 public class LoginInterceptor implements HandlerInterceptor {
 
-    public static final String USERNAME = "username";
-    public static final String _ID = "_id";
+    public static final String USER_NAME = "username";
+    public static final String USER_ID = "_id";
 
     @Resource
     private JwtTokenUtil jwtTokenUtil;
@@ -44,11 +44,11 @@ public class LoginInterceptor implements HandlerInterceptor {
         Map<String, Claim> claims = jwt.getClaims();
         //获取用户名,密码
         String username = null, userId = null;
-        if (!ObjectUtils.isEmpty(claims.get(USERNAME))) {
-            username = claims.get(USERNAME).asString();
+        if (!ObjectUtils.isEmpty(claims.get(USER_NAME))) {
+            username = claims.get(USER_NAME).asString();
         }
-        if (!ObjectUtils.isEmpty(claims.get(_ID))) {
-            userId = claims.get(_ID).asString();
+        if (!ObjectUtils.isEmpty(claims.get(USER_ID))) {
+            userId = claims.get(USER_ID).asString();
         }
         //判空
         if (ObjectUtils.isEmpty(username) || ObjectUtils.isEmpty(userId)) {

--- a/survey-server/src/main/java/com/xiaojusurvey/engine/interceptor/LoginInterceptor.java
+++ b/survey-server/src/main/java/com/xiaojusurvey/engine/interceptor/LoginInterceptor.java
@@ -39,14 +39,14 @@ public class LoginInterceptor implements HandlerInterceptor {
         //查询用户信息
         Map<String, Claim> claims = jwt.getClaims();
         //获取用户名,密码
-        String username = claims.get("username").asString();
-        String password = claims.get("password").asString();
+        String username = String.valueOf(claims.get("username"));
+        String userId = String.valueOf(claims.get("_id"));
         //判空
-        if (ObjectUtils.isEmpty(username) || ObjectUtils.isEmpty(password)) {
+        if (ObjectUtils.isEmpty(username) || ObjectUtils.isEmpty(userId)) {
             //token超时
             throw new ServiceException(RespErrorCode.USER_CREDENTIALS_ERROR.getMessage(), RespErrorCode.USER_CREDENTIALS_ERROR.getCode());
         }
-        User user = userService.loadUserByUsernameAndPassword(username, password);
+        User user = userService.getUserById(userId);
         request.setAttribute("user", user);
         return HandlerInterceptor.super.preHandle(request, response, handler);
     }


### PR DESCRIPTION
改动原因：
   1.  java端接口注册的用户没法在node端登录
   2. jwt存储了用户password关键信息
   3. 方便java版本开发的同学做接口验证调试
改动内容：
    1. 去除jwt存储password关键信息；token创建逻辑同node，jwt信息实现node和java互通
    2. 新增hash256方法，用户注册password加密逻辑同node,实现java端注册的账号登录和node版本互通

改动验证：
    1. 调用java注册用户，在mian分支下node服务正常登录，且node服务注册的用户在java版本的登录接口正常登陆
    2. node服务下的token在java端可以正常获取到用户信息