### PR TITLE
[Fix]: 修复生成的 token 缺失 id导致登录校验出错

### DIFF
--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/impl/AuthServiceImpl.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/auth/impl/AuthServiceImpl.java
@@ -63,6 +63,7 @@ public class AuthServiceImpl implements AuthService {
         user.setUsername(userParam.getUsername());
         user.setPassword(AuthUtil.hash256(userParam.getPassword()));
         mongoRepository.save(user);
+        userParam.setId(user.getId());
         return createTokenAndDeleteCaptcha(userParam);
     }
 
@@ -88,7 +89,8 @@ public class AuthServiceImpl implements AuthService {
         //验证码
         checkCaptchaIsCorrect(userParam.getCaptchaId(), userParam.getCaptcha());
         //用户验证
-        userService.loadUserByUsernameAndPassword(userParam.getUsername(), userParam.getPassword());
+        User user = userService.loadUserByUsernameAndPassword(userParam.getUsername(), userParam.getPassword());
+        userParam.setId(user.getId());
         //生成token
         return createTokenAndDeleteCaptcha(userParam);
     }


### PR DESCRIPTION
1.生成 token  方法的传参增加 id

