### PR TITLE
fix：修复编辑页在不同element版本下表现不一致问题

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "clipboard": "^2.0.11",
     "crypto-js": "^4.2.0",
     "echarts": "^5.5.0",
-    "element-plus": "^2.7.0",
+    "element-plus": "^2.8.1",
     "lodash-es": "^4.17.21",
     "moment": "^2.29.4",
     "nanoid": "^5.0.7",

--- a/web/src/management/pages/edit/modules/questionModule/CatalogPanel.vue
+++ b/web/src/management/pages/edit/modules/questionModule/CatalogPanel.vue
@@ -22,8 +22,6 @@ const tabSelected = ref<string>('0')
   height: 100%;
   box-shadow: none;
   border: none;
-  display: flex;
-  flex-direction: column;
   :deep(.el-tabs__nav) {
     width: 100%;
   }

--- a/web/src/management/pages/edit/modules/questionModule/SetterPanel.vue
+++ b/web/src/management/pages/edit/modules/questionModule/SetterPanel.vue
@@ -102,8 +102,6 @@ watch(
     width: 360px;
     height: 100%;
     border: none;
-    display: flex;
-    flex-direction: column;
 
     .el-tabs__nav {
       width: 100%;

--- a/web/src/materials/questions/widgets/EditOptions/Options/OptionEditBar.vue
+++ b/web/src/materials/questions/widgets/EditOptions/Options/OptionEditBar.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script setup>
-import { ref, inject } from 'vue'
+import { inject } from 'vue'
 import ExtraIcon from '../ExtraIcon/index.vue'
 
 defineProps({
@@ -34,13 +34,7 @@ defineProps({
 })
 const emit = defineEmits(['addOther', 'optionChange', 'change'])
 
-const moduleConfig = inject('moduleConfig')
 const slots = inject('slots')
-
-const optionConfigVisible = ref(false)
-const openOptionConfig = () => {
-  optionConfigVisible.value = true
-}
 
 const addOther = () => {
   emit('addOther')


### PR DESCRIPTION
问题表现：![image](https://github.com/user-attachments/assets/d789809a-0ff9-4d0f-bd7e-03370980d6e9)

根因：最新element-plust调整了tab组件的结构和样式，同时业务组件自定义flex-direction: column;导致tab表现异常

解决方案：声明element-plus的最小版本为2.8.1，去掉自定义的样式flex-direction: column; 