### PR TITLE
fix: 修复富文本编辑器上传图片

### DIFF
--- a/web/src/materials/questions/widgets/TitleModules/TitleContent/index.jsx
+++ b/web/src/materials/questions/widgets/TitleModules/TitleContent/index.jsx
@@ -48,9 +48,9 @@ export default defineComponent({
 
     watch(status, (v) => {
       if (v === 'edit') {
-        document.addEventListener('click', handleDocumentClick)
+        document.addEventListener('click', handleDocumentClick, {capture: true})
       } else {
-        document.removeEventListener('click', handleDocumentClick)
+        document.removeEventListener('click', handleDocumentClick, {capture: true})
       }
     })
 

--- a/web/src/materials/questions/widgets/TitleModules/TitleContent/index.jsx
+++ b/web/src/materials/questions/widgets/TitleModules/TitleContent/index.jsx
@@ -96,7 +96,8 @@ export default defineComponent({
 
     function handleDocumentClick(e) {
       const richEditorDOM = moduleTitleRef.value.querySelector('.rich-editor')
-      const isClickRichEditor = richEditorDOM?.contains(e.target)
+      const isUploadImage = e.target.type === 'file' && e.target.tagName.toLowerCase() === 'input' // 富文本上传图片点击事件触发到input file 元素上了, 该元素插入到body了
+      const isClickRichEditor = richEditorDOM?.contains(e.target) || isUploadImage
 
       if (status.value === 'edit' && richEditorDOM && !isClickRichEditor) {
         // 监听编辑状态时点击非编辑区域


### PR DESCRIPTION
<!-- 请严格遵循贡献规范：https://xiaojusurvey.didi.cn/docs/next/share/%E8%B4%A1%E7%8C%AE%E6%B5%81%E7%A8%8B -->

### 改动内容
1. 修正前端题目TitleModule组件点击工具条上传图片触发关闭title编辑的bug

### Issue
<!-- 确保大的改动创建一个Issue描述详情：https://github.com/didi/xiaoju-survey/issues/new?assignees=&labels=&projects=&template=pr_report.md&title=[类型]: xxx -->
