### PR TITLE
fix:修复peking分支代码cr问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules
 dist
 
 package-lock.json
-yarn.lock
 
 # local env files
 .env.local


### PR DESCRIPTION
1. ignore去掉重复的yarn.lock