### PR TITLE
[Chore]: 优化 Dockerfile 缩小镜像体积

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/node_modules
+**/dist
+**/logs
+**/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,38 @@
 # 镜像集成
-FROM node:18
+FROM node:18-slim AS builder
+
+WORKDIR /builder
+
+# 复制文件到工作区间
+COPY web/ /builder/web/
+COPY server/ /builder/server/
+
+RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources && \
+    npm config set registry https://registry.npmmirror.com && \
+    apt-get update && apt-get install -y build-essential && \
+    cd /builder/web && npm install && npm run build-only && \
+    cd /builder/server && npm install && npm run build
+
+
+FROM node:18-slim
 
 # 设置工作区间
 WORKDIR /xiaoju-survey
 
-# 复制文件到工作区间
-COPY . /xiaoju-survey
-
 # 安装nginx
-RUN apt-get update && apt-get install -y nginx
+RUN sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources && \
+    npm config set registry https://registry.npmmirror.com && \
+    apt-get update && apt-get install -y nginx
 
-RUN npm config set registry https://registry.npmjs.org/
-
-# 安装项目依赖
-RUN cd /xiaoju-survey/web && npm install && npm run build-only
-
+# 仅复制运行需要的文件到工作区间
+COPY --from=builder /builder/web/dist/ /xiaoju-survey/web/dist/
+COPY --from=builder /builder/server/dist/ /xiaoju-survey/server/dist/
+COPY --from=builder /builder/server/node_modules/ /xiaoju-survey/server/node_modules/
+COPY --from=builder /builder/server/public/ /xiaoju-survey/server/public/
+COPY --from=builder /builder/server/package*.json /builder/server/.env* /xiaoju-survey/server/
+COPY docker-run.sh /xiaoju-survey/docker-run.sh
 # 覆盖nginx配置文件
-COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
-
-RUN cd /xiaoju-survey/server && npm install && npm run build
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
 # 暴露端口 需要跟nginx的port一致
 EXPOSE 80


### PR DESCRIPTION
改动原因：镜像包太大，需要下载的时间长，下载后的完整体积在1.5G左右

改动内容：`Dockerfile`、`.dockerignore`

改动验证：编译镜像后成功运行，运行情况与 npm 启动一样。

使用时发现问卷等无法正常使用，但经过验证并非本次改动导致，以 npm 启动的服务有同样的问题。