### PR TITLE
[Feat]:  实现C端接口，获取已发布问卷的schema

### DIFF
--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/survey/SurveyResponseService.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/survey/SurveyResponseService.java
@@ -1,0 +1,15 @@
+package com.xiaojusurvey.engine.core.survey;
+
+import com.xiaojusurvey.engine.core.survey.vo.SurveyResponseSchemaOutVO;
+
+/**
+ * 问卷提交服务
+ *
+ * @author zsh
+ * @date: 2025/1/21
+ */
+public interface SurveyResponseService {
+
+
+    SurveyResponseSchemaOutVO getResponseSchema(String surveyPath);
+}

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/survey/impl/SurveyResponseServiceImpl.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/survey/impl/SurveyResponseServiceImpl.java
@@ -1,0 +1,35 @@
+package com.xiaojusurvey.engine.core.survey.impl;
+
+import com.xiaojusurvey.engine.common.entity.survey.SurveyPublish;
+import com.xiaojusurvey.engine.core.survey.SurveyResponseService;
+import com.xiaojusurvey.engine.core.survey.vo.SurveyResponseSchemaOutVO;
+import com.xiaojusurvey.engine.repository.MongoRepository;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+import javax.annotation.Resource;
+
+/**
+ * @Author: zsh
+ * @CreateTime: 2025/1/21
+ * @Description: 问卷提交服务
+ */
+@Service
+public class SurveyResponseServiceImpl implements SurveyResponseService {
+
+    @Resource
+    private MongoRepository mongoRepository;
+
+    @Override
+    public SurveyResponseSchemaOutVO getResponseSchema(String surveyPath) {
+        Query query = new Query(Criteria.where("surveyPath").is(surveyPath));
+        SurveyPublish surveyPublish = mongoRepository.findOne(query, SurveyPublish.class);
+        SurveyResponseSchemaOutVO responseSchema = new SurveyResponseSchemaOutVO();
+        responseSchema.setPageId(surveyPublish.getPageId());
+        responseSchema.setCode(surveyPublish.getCode());
+        responseSchema.setSurveyPath(surveyPath);
+        responseSchema.setTitle(surveyPublish.getTitle());
+        responseSchema.setCurStatus(surveyPublish.getCurStatus());
+        return responseSchema;
+    }
+}

--- a/survey-core/src/main/java/com/xiaojusurvey/engine/core/survey/vo/SurveyResponseSchemaOutVO.java
+++ b/survey-core/src/main/java/com/xiaojusurvey/engine/core/survey/vo/SurveyResponseSchemaOutVO.java
@@ -1,0 +1,27 @@
+package com.xiaojusurvey.engine.core.survey.vo;
+
+import com.xiaojusurvey.engine.common.entity.BaseEntity;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * 问卷schema
+ *
+ * @author zsh
+ * @date: 2025/1/21
+ */
+@Data
+public class SurveyResponseSchemaOutVO extends BaseEntity implements Serializable  {
+
+    private static final long serialVersionUID = 98953698447536L;
+
+    private  String title;
+
+    private  String surveyPath;
+
+    private String pageId;
+
+    private Map<String, Object> code;
+}

--- a/survey-server/src/main/java/com/xiaojusurvey/engine/controller/SurveyResponseController.java
+++ b/survey-server/src/main/java/com/xiaojusurvey/engine/controller/SurveyResponseController.java
@@ -1,0 +1,32 @@
+package com.xiaojusurvey.engine.controller;
+
+
+import com.xiaojusurvey.engine.common.rpc.RpcResult;
+import com.xiaojusurvey.engine.common.util.RpcResultUtil;
+import com.xiaojusurvey.engine.core.survey.SurveyResponseService;
+import com.xiaojusurvey.engine.core.survey.vo.SurveyResponseSchemaOutVO;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+
+@RequestMapping("/api")
+@RestController
+public class SurveyResponseController {
+
+    @Resource
+    private SurveyResponseService surveyResponseService;
+
+    /**
+     * 获取已发布问卷的schema
+     * @param surveyPath
+     * @return
+     */
+    @GetMapping("/responseSchema/getSchema")
+    public RpcResult<SurveyResponseSchemaOutVO> getSchema(@RequestParam("surveyPath") String surveyPath) {
+        return RpcResultUtil.createSuccessResult(surveyResponseService.getResponseSchema(surveyPath));
+    }
+
+}

--- a/survey-server/src/test/java/com/xiaojusurvey/engine/controller/SurveyResponseControllerTest.java
+++ b/survey-server/src/test/java/com/xiaojusurvey/engine/controller/SurveyResponseControllerTest.java
@@ -1,0 +1,33 @@
+package com.xiaojusurvey.engine.controller;
+
+
+import com.xiaojusurvey.engine.common.rpc.RpcResult;
+import com.xiaojusurvey.engine.core.survey.SurveyResponseService;
+import com.xiaojusurvey.engine.core.survey.vo.SurveyResponseSchemaOutVO;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class SurveyResponseControllerTest {
+
+    @Mock
+    private SurveyResponseService surveyResponseService;
+
+
+    @InjectMocks
+    private SurveyResponseController surveyResponseController;
+
+
+    @Test
+    public void getSchema() {
+
+        RpcResult<SurveyResponseSchemaOutVO> surveyResult = surveyResponseController.getSchema("testSurveyPath");
+        Assert.assertTrue(surveyResult.getSuccess());
+
+
+    }
+}


### PR DESCRIPTION
<!-- 请严格遵循贡献规范：https://xiaojusurvey.didi.cn/docs/next/share/%E8%B4%A1%E7%8C%AE%E6%B5%81%E7%A8%8B -->

### 改动内容
<!-- 不同功能拆分成多个PR。简洁记录改动内容，用1、2、3...分序号描述改动点 -->
实现c端接口 获取已发布问卷的schema
### Issue
<!-- 确保大的改动创建一个Issue描述详情：https://github.com/didi/xiaoju-survey/issues/new?assignees=&labels=&projects=&template=pr_report.md&title=[类型]: xxx -->
java版后端