### PR TITLE
[Fix]: 解决getCurrentInstance()在开发环境和生产环境拿到的值不一样

### DIFF
--- a/web/src/management/pages/edit/components/Picker/event.ts
+++ b/web/src/management/pages/edit/components/Picker/event.ts
@@ -1,4 +1,3 @@
-
 interface IEvent {
   handleConfirm: () => void,
   handleCancel: () => void
@@ -6,7 +5,9 @@ interface IEvent {
 
 const useEvent = ({ emit, ctx }: any): IEvent => {
   const handleConfirm = () => {
-    emit('confirm', ctx.list[ctx.index])
+    const list = ctx.list.value
+    const index = ctx.index.value
+    emit('confirm', list[index])
     emit('update:modelValue', false)
   }
 

--- a/web/src/management/pages/edit/components/Picker/index.vue
+++ b/web/src/management/pages/edit/components/Picker/index.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-import { defineComponent, getCurrentInstance,watch,onMounted,onBeforeUnmount } from 'vue'
+import { defineComponent, watch,onMounted,onBeforeUnmount } from 'vue'
 import useList from './list'
 import useEvent from './event'
 
@@ -37,11 +37,11 @@ export default defineComponent({
     }
   },
   setup(props, { emit }) {
-    const { ctx } = getCurrentInstance()
     const $useList = useList(props)
-    const $useEvent = useEvent({ emit, ctx })
+    const { list, index } = $useList
+    const $useEvent = useEvent({ emit, ctx: { list, index} })
 
-
+    
     const hideOverflow = () => {
       document.documentElement.style.overflow = 'hidden';
     }
@@ -92,7 +92,6 @@ export default defineComponent({
         restoreOverflow()
       }
     })
-
 
     return {
       ...$useList,


### PR DESCRIPTION
修复在生产环境c端的多级联动题型无法选中 bug 