### PR TITLE
fix(web): add @element-plus/icons-vue dependency for new UI components

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@element-plus/icons-vue": "^2.3.2",
     "@logicflow/core": "2.0.0",
     "@logicflow/extension": "2.0.0",
     "@wangeditor/editor": "^5.1.23",


### PR DESCRIPTION
### 改动内容
1. 在 `package.json` 中新增依赖 `@element-plus/icons-vue`，用于支持 Element Plus 的图标组件。  
2. 修复 `ExcelImport.vue` 等组件中出现的 `Failed to resolve import "@element-plus/icons-vue"` 报错。   

### Issue
Closes #529 

### 备注
- 本 PR 仅涉及依赖修复，不包含业务逻辑改动。  
- 合并后请运行 `pnpm install` 或 `npm install` 以同步依赖。