### PR TITLE
feat: 修复第一次进入页面报错的问题

### DIFF
--- a/web/src/management/api/base.js
+++ b/web/src/management/api/base.js
@@ -22,6 +22,9 @@ instance.interceptors.response.use(
     }
     const res = response.data
     if (res.code === CODE_MAP.NO_AUTH || res.code === CODE_MAP.ERR_AUTH) {
+      // 当用户凭证错误或没有权限时退出登录
+      const userStore = useUserStore()
+      userStore.logout()
       router.replace({
         name: 'login'
       })

--- a/web/src/management/pages/login/LoginPage.vue
+++ b/web/src/management/pages/login/LoginPage.vue
@@ -79,9 +79,19 @@ import { getPasswordStrength, login, register } from '@/management/api/auth'
 import { refreshCaptcha as refreshCaptchaApi } from '@/management/api/captcha'
 import { CODE_MAP } from '@/management/api/base'
 import { useUserStore } from '@/management/stores/user'
+import { getUserInfo } from '@/management/utils/storage'
+import { getUserInfo as userInfoApi } from '@/management/api/auth'
 
 const route = useRoute()
 const router = useRouter()
+
+const userinfo = getUserInfo()
+if (userinfo?.userInfo?.token) {
+  // 如果有《用户凭证》且可以获取用户信息则直接跳转到 survey 页面
+  userInfoApi().then(() => {
+    router.push({ name: 'survey' })
+  })
+}
 
 interface FormData {
   name: string

--- a/web/src/management/router/index.ts
+++ b/web/src/management/router/index.ts
@@ -18,7 +18,7 @@ import { useEditStore } from '@/management/stores/edit'
 const routes: RouteRecordRaw[] = [
   {
     path: '/',
-    redirect: '/survey'
+    redirect: '/login'
   },
   {
     path: '/survey',


### PR DESCRIPTION
<!-- 请严格遵循贡献规范：https://xiaojusurvey.didi.cn/docs/next/share/%E8%B4%A1%E7%8C%AE%E6%B5%81%E7%A8%8B -->

### 修复问题
![img_v3_02rq_92f68249-a279-4794-bd11-9f2a88b744ag](https://github.com/user-attachments/assets/cbbedcb1-c7cd-4a87-8b7d-a92e58da407d)


### 改动内容
<!-- 不同功能拆分成多个PR。简洁记录改动内容，用1、2、3...分序号描述改动点 -->

1. 将根目录 redirect 到登录页面。
2. 在登录页面 判断用户是否有登录状态，以及登录状态是否有效。
- 如果登录状态无效则停在当前页面
- 如果登录状态有效则跳转到 survey
3. 在用户登录状态失效或者没有权限异常时清除已有的登录凭证。并跳转到登录页

### Issue
<!-- 确保大的改动创建一个Issue描述详情：https://github.com/didi/xiaoju-survey/issues/new?assignees=&labels=&projects=&template=pr_report.md&title=[类型]: xxx -->
