### PR TITLE
fix: 修改数据导出时 others 的字段没有被导出的问题

### DIFF
--- a/server/src/modules/survey/services/downloadTask.service.ts
+++ b/server/src/modules/survey/services/downloadTask.service.ts
@@ -195,6 +195,12 @@ export class DownloadTaskService {
             const $ = load(item.title);
             const text = $.text();
             xlsxHead.push(text);
+            // 处理 othersCode 的数据
+            item?.othersCode?.map((other) => {
+              const $ = load(other.option);
+              const subtext = $.text();
+              xlsxHead.push(`${text}-${subtext}`);
+            });
           }
         }
         for (const bodyItem of listBody) {
@@ -209,6 +215,18 @@ export class DownloadTaskService {
             } else {
               bodyData.push(val);
             }
+            // 处理 othersCode 的数据
+            headItem?.othersCode?.map((other) => {
+              const field = other.code;
+              const val = get(bodyItem, field, '');
+              if (typeof val === 'string') {
+                const $ = load(val);
+                const text = $.text();
+                bodyData.push(text);
+              } else {
+                bodyData.push(val);
+              }
+            });
           }
           xlsxBody.push(bodyData);
         }


### PR DESCRIPTION
<!-- 请严格遵循贡献规范：https://xiaojusurvey.didi.cn/docs/next/share/%E8%B4%A1%E7%8C%AE%E6%B5%81%E7%A8%8B -->

<img width="1513" height="175" alt="image" src="https://github.com/user-attachments/assets/4eaa9dc3-0103-4070-9d48-7a2f1db5f48b" />


### 改动内容
<!-- 不同功能拆分成多个PR。简洁记录改动内容，用1、2、3...分序号描述改动点 -->

增加对 othersCode 的遍历 从而把other 的数据展示出来。




