### PR TITLE
feat: 支持答题限时

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -68,6 +68,7 @@
     "@types/node": "^20.3.1",
     "@types/node-forge": "^1.3.11",
     "@types/supertest": "^2.0.12",
+    "@types/validator": "^13.15.10",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "cross-env": "^7.0.3",

--- a/server/src/interfaces/survey.ts
+++ b/server/src/interfaces/survey.ts
@@ -189,6 +189,23 @@ export interface BottomConf {
   logoImageWidth: string;
 }
 
+export interface LogicCondition {
+  field: string;
+  operator: string;
+  value: string | string[];
+}
+
+export interface LogicRule {
+  target: string;
+  scope: string;
+  conditions: LogicCondition[];
+}
+
+export interface LogicConf {
+  showLogicConf?: LogicRule[];
+  jumpLogicConf?: LogicRule[];
+}
+
 export interface SurveySchemaInterface {
   bannerConf: BannerConf;
   dataConf: DataConf;
@@ -196,4 +213,5 @@ export interface SurveySchemaInterface {
   baseConf: BaseConf;
   skinConf: SkinConf;
   bottomConf: BottomConf;
+  logicConf?: LogicConf;
 }

--- a/server/src/interfaces/survey.ts
+++ b/server/src/interfaces/survey.ts
@@ -135,6 +135,14 @@ export enum MemberType {
   EMAIL = 'EMAIL',
 }
 
+export type AnswerTimeUnit = 'minute' | 'second';
+
+export interface AnswerDurationConf {
+  enabled: boolean;
+  duration: number;
+  unit: AnswerTimeUnit;
+}
+
 export interface BaseConf {
   beginTime: string;
   endTime: string;
@@ -154,6 +162,10 @@ export interface BaseConf {
   whitelist?: string[];
   // 提示语
   whitelistTip?: string;
+  // 答题限时（最长时长）配置
+  answerTimeLimit?: AnswerDurationConf;
+  // 最短答题时长配置
+  answerMinDuration?: AnswerDurationConf;
 }
 
 export interface SkinConf {

--- a/server/src/models/surveyResponse.entity.ts
+++ b/server/src/models/surveyResponse.entity.ts
@@ -28,6 +28,9 @@ export class SurveyResponse extends BaseEntity {
   @Column()
   channelId: string;
 
+  @Column({ default: false })
+  autoSubmit?: boolean;
+
   @BeforeInsert()
   async onDataInsert() {
     return await pluginManager.triggerHook('encryptResponseData', this);

--- a/server/src/modules/survey/__test/normalizeAnswerTime.spec.ts
+++ b/server/src/modules/survey/__test/normalizeAnswerTime.spec.ts
@@ -1,0 +1,131 @@
+import {
+  normalizeAnswerDurationConf,
+  normalizeBaseConfAnswerTime,
+} from '../utils/normalizeAnswerTime';
+import { BaseConf } from 'src/interfaces/survey';
+
+// T-TEST-02：updateConf 参数 normalize（unit 缺省 / duration 非法 / 越界 / enabled 强制 boolean）
+describe('normalizeAnswerTime util (T-TEST-02 / T-BE-04)', () => {
+  describe('normalizeAnswerDurationConf', () => {
+    it('returns undefined for undefined / null input', () => {
+      expect(normalizeAnswerDurationConf(undefined)).toBeUndefined();
+      expect(normalizeAnswerDurationConf(null)).toBeUndefined();
+    });
+
+    it('defaults unit to "minute" when missing', () => {
+      const out = normalizeAnswerDurationConf({ enabled: true, duration: 30 });
+      expect(out).toEqual({ enabled: true, duration: 30, unit: 'minute' });
+    });
+
+    it('defaults unit to "minute" when illegal', () => {
+      const out = normalizeAnswerDurationConf({
+        enabled: true,
+        duration: 30,
+        unit: 'hour',
+      });
+      expect(out?.unit).toBe('minute');
+    });
+
+    it('accepts unit = "second"', () => {
+      const out = normalizeAnswerDurationConf({
+        enabled: true,
+        duration: 30,
+        unit: 'second',
+      });
+      expect(out?.unit).toBe('second');
+    });
+
+    it('coerces non-positive / non-integer / non-numeric duration to 30', () => {
+      expect(
+        normalizeAnswerDurationConf({ enabled: true, duration: 0 })?.duration,
+      ).toBe(30);
+      expect(
+        normalizeAnswerDurationConf({ enabled: true, duration: -5 })?.duration,
+      ).toBe(30);
+      expect(
+        normalizeAnswerDurationConf({ enabled: true, duration: 1.5 })?.duration,
+      ).toBe(30);
+      expect(
+        normalizeAnswerDurationConf({
+          enabled: true,
+          duration: 'abc' as any,
+        })?.duration,
+      ).toBe(30);
+      expect(
+        normalizeAnswerDurationConf({
+          enabled: true,
+          duration: NaN,
+        })?.duration,
+      ).toBe(30);
+    });
+
+    it('keeps a valid positive-integer duration as-is (no upper bound at BE)', () => {
+      expect(
+        normalizeAnswerDurationConf({ enabled: true, duration: 1 })?.duration,
+      ).toBe(1);
+      // BE 不强制上下限（CL-016 由 FE 兜底）
+      expect(
+        normalizeAnswerDurationConf({ enabled: true, duration: 99999 })
+          ?.duration,
+      ).toBe(99999);
+    });
+
+    it('coerces enabled to boolean', () => {
+      expect(
+        normalizeAnswerDurationConf({
+          enabled: 1 as any,
+          duration: 30,
+          unit: 'minute',
+        })?.enabled,
+      ).toBe(false);
+      expect(
+        normalizeAnswerDurationConf({
+          enabled: 'yes' as any,
+          duration: 30,
+          unit: 'minute',
+        })?.enabled,
+      ).toBe(false);
+      expect(
+        normalizeAnswerDurationConf({
+          enabled: true,
+          duration: 30,
+          unit: 'minute',
+        })?.enabled,
+      ).toBe(true);
+      expect(
+        normalizeAnswerDurationConf({
+          duration: 30,
+          unit: 'minute',
+        } as any)?.enabled,
+      ).toBe(false);
+    });
+  });
+
+  describe('normalizeBaseConfAnswerTime', () => {
+    it('is a no-op when baseConf is undefined / answer fields missing', () => {
+      expect(() => normalizeBaseConfAnswerTime(undefined)).not.toThrow();
+      const baseConf = { beginTime: '' } as unknown as BaseConf;
+      normalizeBaseConfAnswerTime(baseConf);
+      expect(baseConf.answerTimeLimit).toBeUndefined();
+      expect(baseConf.answerMinDuration).toBeUndefined();
+    });
+
+    it('normalizes both answerTimeLimit and answerMinDuration in place', () => {
+      const baseConf = {
+        answerTimeLimit: { enabled: true, duration: -1, unit: 'hour' },
+        answerMinDuration: { enabled: 'on', duration: 0 },
+      } as unknown as BaseConf;
+      normalizeBaseConfAnswerTime(baseConf);
+      expect(baseConf.answerTimeLimit).toEqual({
+        enabled: true,
+        duration: 30,
+        unit: 'minute',
+      });
+      expect(baseConf.answerMinDuration).toEqual({
+        enabled: false,
+        duration: 30,
+        unit: 'minute',
+      });
+    });
+  });
+});

--- a/server/src/modules/survey/controllers/survey.controller.ts
+++ b/server/src/modules/survey/controllers/survey.controller.ts
@@ -38,6 +38,7 @@ import { UserService } from 'src/modules/auth/services/user.service';
 
 import { FilesInterceptor } from '@nestjs/platform-express';
 import * as XLSX from 'xlsx';
+import { normalizeBaseConfAnswerTime } from '../utils/normalizeAnswerTime';
 
 interface ExcelQuestion {
   title: string;
@@ -189,6 +190,11 @@ export class SurveyController {
     const username = req.user.username;
 
     const configData = value.configData;
+    // 防御性 normalize：B 端保存「答题限制 / 最短时长」配置时做参数兜底
+    // unit 缺省 / 非法 → 'minute'；duration 非正整数 → 30；enabled 强制 boolean
+    if (configData?.baseConf) {
+      normalizeBaseConfAnswerTime(configData.baseConf);
+    }
     await this.surveyConfService.saveSurveyConf({
       surveyId,
       schema: configData,

--- a/server/src/modules/survey/utils/normalizeAnswerTime.ts
+++ b/server/src/modules/survey/utils/normalizeAnswerTime.ts
@@ -1,0 +1,52 @@
+import {
+  AnswerDurationConf,
+  AnswerTimeUnit,
+  BaseConf,
+} from 'src/interfaces/survey';
+
+const DEFAULT_DURATION = 30;
+const VALID_UNITS: AnswerTimeUnit[] = ['minute', 'second'];
+
+function normalizeUnit(unit: any): AnswerTimeUnit {
+  return VALID_UNITS.includes(unit) ? unit : 'minute';
+}
+
+function normalizeDuration(duration: any): number {
+  if (
+    typeof duration !== 'number' ||
+    !Number.isFinite(duration) ||
+    !Number.isInteger(duration) ||
+    duration <= 0
+  ) {
+    return DEFAULT_DURATION;
+  }
+  return duration;
+}
+
+export function normalizeAnswerDurationConf(
+  conf: any,
+): AnswerDurationConf | undefined {
+  if (conf === undefined || conf === null) return undefined;
+  if (typeof conf !== 'object') return undefined;
+  return {
+    enabled: conf.enabled === true,
+    duration: normalizeDuration(conf.duration),
+    unit: normalizeUnit(conf.unit),
+  };
+}
+
+export function normalizeBaseConfAnswerTime(
+  baseConf: BaseConf | undefined,
+): void {
+  if (!baseConf) return;
+  if (baseConf.answerTimeLimit !== undefined) {
+    baseConf.answerTimeLimit = normalizeAnswerDurationConf(
+      baseConf.answerTimeLimit,
+    );
+  }
+  if (baseConf.answerMinDuration !== undefined) {
+    baseConf.answerMinDuration = normalizeAnswerDurationConf(
+      baseConf.answerMinDuration,
+    );
+  }
+}

--- a/server/src/modules/surveyResponse/__test/surveyResponse.controller.spec.ts
+++ b/server/src/modules/surveyResponse/__test/surveyResponse.controller.spec.ts
@@ -271,6 +271,8 @@ describe('SurveyResponseController', () => {
             },
           ],
         },
+        channelId: undefined,
+        autoSubmit: false,
       });
 
       expect(clientEncryptService.deleteEncryptInfo).toHaveBeenCalledWith(
@@ -370,6 +372,100 @@ describe('SurveyResponseController', () => {
     });
   });
 
+  // T-TEST-01: autoSubmit=true 跳过必填、autoSubmit=false/undefined 仍执行必填
+  describe('createResponseProcess autoSubmit (T-TEST-01 / T-BE-03)', () => {
+    const buildParams = (overrides: Record<string, any> = {}) => ({
+      surveyPath: 'EBzdmnSp',
+      clientTime: Date.now(),
+      diffTime: 0,
+      data: {
+        data458: '15000000000',
+        data515: '115019',
+        data450: '450111000000000000',
+        data405: '浙江省杭州市西湖区xxx',
+        data770: '123456@qq.com',
+      },
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      jest
+        .spyOn(responseSchemaService, 'getResponseSchemaByPath')
+        .mockResolvedValue(mockResponseSchema);
+      jest
+        .spyOn(surveyResponseService, 'getSurveyResponseTotalByPath')
+        .mockResolvedValue(0);
+      jest
+        .spyOn(surveyResponseService, 'createSurveyResponse')
+        .mockResolvedValue({
+          _id: new ObjectId('65fc2dd77f4520858046e129'),
+          surveyPath: 'EBzdmnSp',
+        } as unknown as SurveyResponse);
+    });
+
+    it('autoSubmit=true 时跳过必填校验且持久化 autoSubmit:true', async () => {
+      const params = buildParams({
+        autoSubmit: true,
+        data: {}, // 必填全部缺失
+      });
+      await expect(
+        controller.createResponseProcess(params, false),
+      ).resolves.toBeUndefined();
+      expect(surveyResponseService.createSurveyResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ autoSubmit: true }),
+      );
+    });
+
+    it('autoSubmit=false 时必填项缺失抛出 PARAMETER_ERROR', async () => {
+      const params = buildParams({
+        autoSubmit: false,
+        data: {}, // 必填全部缺失
+      });
+      await expect(
+        controller.createResponseProcess(params, false),
+      ).rejects.toThrow(HttpException);
+      expect(surveyResponseService.createSurveyResponse).not.toHaveBeenCalled();
+    });
+
+    it('autoSubmit 缺省（undefined）等价于 false：必填缺失仍抛出', async () => {
+      const params = buildParams({ data: {} });
+      await expect(
+        controller.createResponseProcess(params, false),
+      ).rejects.toThrow(HttpException);
+      expect(surveyResponseService.createSurveyResponse).not.toHaveBeenCalled();
+    });
+
+    it('autoSubmit=false 且必填齐全：写入 autoSubmit:false', async () => {
+      const params = buildParams({ autoSubmit: false });
+      await controller.createResponseProcess(params, false);
+      expect(surveyResponseService.createSurveyResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ autoSubmit: false }),
+      );
+    });
+
+    // TC-INV-01：必填校验必须落在 6 步准入校验链全部完成之后（design §4.4 / FR-030）
+    // 断言 counterService.checkAndUpdateOptionCount 在必填校验抛出之前被调用过
+    it('必填校验在 counterService.checkAndUpdateOptionCount 之后执行（I-BIZ-4 顺序）', async () => {
+      const counterService = testingModule.get<CounterService>(CounterService);
+      const counterSpy = jest.spyOn(counterService, 'checkAndUpdateOptionCount');
+      counterSpy.mockClear();
+
+      const params = buildParams({
+        autoSubmit: false,
+        data: {}, // 必填全部缺失，触发抛出
+      });
+
+      await expect(
+        controller.createResponseProcess(params, false),
+      ).rejects.toThrow(HttpException);
+
+      // counter 必须在必填抛出之前被调用过
+      expect(counterSpy).toHaveBeenCalledTimes(1);
+      // 写入未发生
+      expect(surveyResponseService.createSurveyResponse).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createResponseWithOpen', () => {
     let appManagerService: AppManagerService;
     let openAuthGuard: OpenAuthGuard;
@@ -384,9 +480,17 @@ describe('SurveyResponseController', () => {
     });
 
     it('should create response with valid auth headers', async () => {
-      // 准备测试数据
+      // 准备测试数据（withOpen 不走 RSA 解密路径，data 需是明文 form values，
+      // 必填字段需齐全才能通过 createResponseProcess 中的必填校验）
       const reqBody = {
         ...cloneDeep(mockSubmitData),
+        data: {
+          data458: '15000000000',
+          data515: '115019',
+          data450: '450111000000000000',
+          data405: '浙江省杭州市西湖区xxx',
+          data770: '123456@qq.com',
+        },
         channelId: '67cecfb37b4d3ae83aea1bdb', // 添加channelId
       };
       const mockContext = {

--- a/server/src/modules/surveyResponse/__test/surveyResponse.controller.spec.ts
+++ b/server/src/modules/surveyResponse/__test/surveyResponse.controller.spec.ts
@@ -522,25 +522,23 @@ describe('SurveyResponseController', () => {
       );
     });
 
-    // TC-INV-01：必填校验必须落在 6 步准入校验链全部完成之后（design §4.4 / FR-030）
-    // 断言 counterService.checkAndUpdateOptionCount 在必填校验抛出之前被调用过
-    it('必填校验在 counterService.checkAndUpdateOptionCount 之后执行（I-BIZ-4 顺序）', async () => {
+    it('必填校验失败时不调用 counterService.checkAndUpdateOptionCount', async () => {
       const counterService = testingModule.get<CounterService>(CounterService);
       const counterSpy = jest.spyOn(counterService, 'checkAndUpdateOptionCount');
       counterSpy.mockClear();
 
       const params = buildParams({
         autoSubmit: false,
-        data: {}, // 必填全部缺失，触发抛出
+        data: {
+          data515: '115019',
+        },
       });
 
       await expect(
         controller.createResponseProcess(params, false),
       ).rejects.toThrow(HttpException);
 
-      // counter 必须在必填抛出之前被调用过
-      expect(counterSpy).toHaveBeenCalledTimes(1);
-      // 写入未发生
+      expect(counterSpy).not.toHaveBeenCalled();
       expect(surveyResponseService.createSurveyResponse).not.toHaveBeenCalled();
     });
   });

--- a/server/src/modules/surveyResponse/__test/surveyResponse.controller.spec.ts
+++ b/server/src/modules/surveyResponse/__test/surveyResponse.controller.spec.ts
@@ -443,6 +443,85 @@ describe('SurveyResponseController', () => {
       );
     });
 
+    it('显示逻辑隐藏的必填项缺失时不阻断提交', async () => {
+      const schema = cloneDeep(mockResponseSchema);
+      (schema.code as any).logicConf = {
+        showLogicConf: [
+          {
+            target: 'data770',
+            scope: 'question',
+            conditions: [
+              {
+                field: 'data515',
+                operator: 'in',
+                value: ['115020'],
+              },
+            ],
+          },
+        ],
+        jumpLogicConf: [],
+      };
+      jest
+        .spyOn(responseSchemaService, 'getResponseSchemaByPath')
+        .mockResolvedValue(schema);
+
+      const params = buildParams({
+        autoSubmit: false,
+        data: {
+          data458: '15000000000',
+          data515: '115019',
+          data450: '450111000000000000',
+          data405: '浙江省杭州市西湖区xxx',
+        },
+      });
+
+      await expect(
+        controller.createResponseProcess(params, false),
+      ).resolves.toBeUndefined();
+      expect(surveyResponseService.createSurveyResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ autoSubmit: false }),
+      );
+    });
+
+    it('跳转逻辑跳过的必填项缺失时不阻断提交', async () => {
+      const schema = cloneDeep(mockResponseSchema);
+      (schema.code as any).logicConf = {
+        showLogicConf: [],
+        jumpLogicConf: [
+          {
+            target: 'data770',
+            scope: 'question',
+            conditions: [
+              {
+                field: 'data515',
+                operator: 'in',
+                value: ['115019'],
+              },
+            ],
+          },
+        ],
+      };
+      jest
+        .spyOn(responseSchemaService, 'getResponseSchemaByPath')
+        .mockResolvedValue(schema);
+
+      const params = buildParams({
+        autoSubmit: false,
+        data: {
+          data458: '15000000000',
+          data515: '115019',
+          data770: '123456@qq.com',
+        },
+      });
+
+      await expect(
+        controller.createResponseProcess(params, false),
+      ).resolves.toBeUndefined();
+      expect(surveyResponseService.createSurveyResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ autoSubmit: false }),
+      );
+    });
+
     // TC-INV-01：必填校验必须落在 6 步准入校验链全部完成之后（design §4.4 / FR-030）
     // 断言 counterService.checkAndUpdateOptionCount 在必填校验抛出之前被调用过
     it('必填校验在 counterService.checkAndUpdateOptionCount 之后执行（I-BIZ-4 顺序）', async () => {

--- a/server/src/modules/surveyResponse/__test/surveyResponse.service.spec.ts
+++ b/server/src/modules/surveyResponse/__test/surveyResponse.service.spec.ts
@@ -64,6 +64,8 @@ describe('SurveyResponseService', () => {
       pageId: surveyData.surveyId,
       secretKeys: [],
       optionTextAndId: surveyData.optionTextAndId,
+      channelId: undefined,
+      autoSubmit: false,
     });
   });
 

--- a/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
+++ b/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
@@ -33,6 +33,18 @@ const optionQuestionType: Array<string> = [
   QUESTION_TYPE.VOTE,
 ];
 
+type LogicCondition = {
+  field: string;
+  operator: string;
+  value: string | string[];
+};
+
+type LogicRule = {
+  target: string;
+  scope: string;
+  conditions: LogicCondition[];
+};
+
 @ApiTags('surveyResponse')
 @Controller('/api/surveyResponse')
 export class SurveyResponseController {
@@ -308,12 +320,15 @@ export class SurveyResponseController {
     // 必填校验：6 步准入校验链全部走完之后、写入之前执行（design §4.4 / FR-030）
     // 仅在 autoSubmit=false 时执行（autoSubmit=true 由超时自动提交触发，跳过必填）
     if (!autoSubmit) {
+      const hiddenFields = this.getHiddenFieldsByLogic({
+        dataList,
+        formValues,
+        logicConf: responseSchema.code?.logicConf,
+      });
       const missingField = (dataList || []).find((questionItem) => {
         if (!questionItem?.isRequired) return false;
-        const v = formValues?.[questionItem.field];
-        if (v === undefined || v === null || v === '') return true;
-        if (Array.isArray(v) && v.length === 0) return true;
-        return false;
+        if (hiddenFields.has(questionItem.field)) return false;
+        return this.isEmptyAnswer(formValues?.[questionItem.field]);
       });
       if (missingField) {
         throw new HttpException(
@@ -367,6 +382,120 @@ export class SurveyResponseController {
     // 入库成功后，要把密钥删掉，防止被重复使用
     if (sessionId) {
       this.clientEncryptService.deleteEncryptInfo(sessionId);
+    }
+  }
+
+  private isEmptyAnswer(value: any): boolean {
+    if (value === undefined || value === null || value === '') return true;
+    if (Array.isArray(value) && value.length === 0) return true;
+    return false;
+  }
+
+  private getHiddenFieldsByLogic({
+    dataList,
+    formValues,
+    logicConf,
+  }: {
+    dataList: Array<any>;
+    formValues: Record<string, any>;
+    logicConf?: {
+      showLogicConf?: LogicRule[];
+      jumpLogicConf?: LogicRule[];
+    };
+  }): Set<string> {
+    const hiddenFields = new Set<string>();
+    const showRules = this.mergeLogicRules(logicConf?.showLogicConf || []);
+    const jumpRules = logicConf?.jumpLogicConf || [];
+    const fieldIndexMap = (dataList || []).reduce((pre, cur, index) => {
+      pre[cur.field] = index;
+      return pre;
+    }, {});
+
+    (dataList || []).forEach((questionItem, index) => {
+      const showRule = showRules.get(`${questionItem.field}:question`);
+      if (showRule && !this.matchLogicRule(showRule, formValues)) {
+        hiddenFields.add(questionItem.field);
+      }
+
+      const matchedJumpRules = jumpRules.filter((rule) => {
+        if (rule.scope !== 'question') return false;
+        if (!rule.conditions?.some((condition) => condition.field === questionItem.field)) {
+          return false;
+        }
+        return this.matchLogicRule(rule, formValues, 'or');
+      });
+      if (!matchedJumpRules.length) return;
+
+      const maxTargetIndex = matchedJumpRules.reduce((pre, rule) => {
+        if (rule.target === 'end') return Math.max(pre, dataList.length);
+        const targetIndex = fieldIndexMap[rule.target];
+        return typeof targetIndex === 'number' ? Math.max(pre, targetIndex) : pre;
+      }, index);
+      dataList
+        .slice(index + 1, maxTargetIndex)
+        .forEach((item) => hiddenFields.add(item.field));
+    });
+
+    return hiddenFields;
+  }
+
+  private mergeLogicRules(rules: LogicRule[]): Map<string, LogicRule> {
+    return (rules || []).reduce((pre, rule) => {
+      const key = `${rule.target}:${rule.scope}`;
+      const existing = pre.get(key);
+      pre.set(key, {
+        ...rule,
+        conditions: [
+          ...(existing?.conditions || []),
+          ...(Array.isArray(rule.conditions) ? rule.conditions : []),
+        ],
+      });
+      return pre;
+    }, new Map<string, LogicRule>());
+  }
+
+  private matchLogicRule(
+    rule: LogicRule,
+    formValues: Record<string, any>,
+    comparor: 'and' | 'or' = 'and',
+  ): boolean {
+    const conditions = Array.isArray(rule.conditions) ? rule.conditions : [];
+    if (comparor === 'or') {
+      return conditions.some((condition) =>
+        this.matchLogicCondition(condition, formValues),
+      );
+    }
+    return conditions.every((condition) =>
+      this.matchLogicCondition(condition, formValues),
+    );
+  }
+
+  private matchLogicCondition(
+    condition: LogicCondition,
+    formValues: Record<string, any>,
+  ): boolean {
+    const answer = formValues?.[condition.field];
+    if (!answer) return false;
+    const expected = condition.value;
+    switch (condition.operator) {
+      case 'eq':
+        return Array.isArray(expected)
+          ? expected.every((v) => answer.includes(v))
+          : answer.includes(expected);
+      case 'in':
+        return Array.isArray(expected)
+          ? expected.some((v) => answer.includes(v))
+          : answer.includes(expected);
+      case 'nin':
+        return Array.isArray(expected)
+          ? expected.some((v) => !answer.includes(v))
+          : !answer.includes(expected);
+      case 'neq':
+        return Array.isArray(expected)
+          ? expected.every((v) => !answer.includes(v))
+          : answer.toString() !== expected;
+      default:
+        return false;
     }
   }
 }

--- a/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
+++ b/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
@@ -284,6 +284,26 @@ export class SurveyResponseController {
     // 生成一个optionTextAndId字段，因为选项文本可能会改，该字段记录当前提交的文本
     const dataList = responseSchema.code.dataConf.dataList;
 
+    // 非超时自动提交时，先做必填校验，避免无效提交占用选项配额
+    if (!autoSubmit) {
+      const hiddenFields = this.getHiddenFieldsByLogic({
+        dataList,
+        formValues,
+        logicConf: responseSchema.code?.logicConf,
+      });
+      const missingField = (dataList || []).find((questionItem) => {
+        if (!questionItem?.isRequired) return false;
+        if (hiddenFields.has(questionItem.field)) return false;
+        return this.isEmptyAnswer(formValues?.[questionItem.field]);
+      });
+      if (missingField) {
+        throw new HttpException(
+          `必填项未填写: ${missingField.field}`,
+          EXCEPTION_CODE.PARAMETER_ERROR,
+        );
+      }
+    }
+
     const optionTextAndId: Record<
       string,
       Array<{ hash: string; text: string }>
@@ -316,27 +336,6 @@ export class SurveyResponseController {
       userAnswer: formValues,
       surveyPath,
     });
-
-    // 必填校验：6 步准入校验链全部走完之后、写入之前执行（design §4.4 / FR-030）
-    // 仅在 autoSubmit=false 时执行（autoSubmit=true 由超时自动提交触发，跳过必填）
-    if (!autoSubmit) {
-      const hiddenFields = this.getHiddenFieldsByLogic({
-        dataList,
-        formValues,
-        logicConf: responseSchema.code?.logicConf,
-      });
-      const missingField = (dataList || []).find((questionItem) => {
-        if (!questionItem?.isRequired) return false;
-        if (hiddenFields.has(questionItem.field)) return false;
-        return this.isEmptyAnswer(formValues?.[questionItem.field]);
-      });
-      if (missingField) {
-        throw new HttpException(
-          `必填项未填写: ${missingField.field}`,
-          EXCEPTION_CODE.PARAMETER_ERROR,
-        );
-      }
-    }
 
     const surveyId = responseSchema.pageId;
 

--- a/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
+++ b/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
@@ -117,6 +117,7 @@ export class SurveyResponseController {
       diffTime: Joi.number(),
       password: Joi.string().allow(null, ''),
       whitelist: Joi.string().allow(null, ''),
+      autoSubmit: Joi.boolean().default(false),
     }).validate(reqBody, { allowUnknown: true });
 
     if (error) {
@@ -158,6 +159,7 @@ export class SurveyResponseController {
       whitelist: whitelistValue,
       data: formValues,
     } = params;
+    const autoSubmit = params.autoSubmit === true;
 
     // 查询schema
     const responseSchema =
@@ -269,6 +271,7 @@ export class SurveyResponseController {
 
     // 生成一个optionTextAndId字段，因为选项文本可能会改，该字段记录当前提交的文本
     const dataList = responseSchema.code.dataConf.dataList;
+
     const optionTextAndId: Record<
       string,
       Array<{ hash: string; text: string }>
@@ -302,6 +305,24 @@ export class SurveyResponseController {
       surveyPath,
     });
 
+    // 必填校验：6 步准入校验链全部走完之后、写入之前执行（design §4.4 / FR-030）
+    // 仅在 autoSubmit=false 时执行（autoSubmit=true 由超时自动提交触发，跳过必填）
+    if (!autoSubmit) {
+      const missingField = (dataList || []).find((questionItem) => {
+        if (!questionItem?.isRequired) return false;
+        const v = formValues?.[questionItem.field];
+        if (v === undefined || v === null || v === '') return true;
+        if (Array.isArray(v) && v.length === 0) return true;
+        return false;
+      });
+      if (missingField) {
+        throw new HttpException(
+          `必填项未填写: ${missingField.field}`,
+          EXCEPTION_CODE.PARAMETER_ERROR,
+        );
+      }
+    }
+
     const surveyId = responseSchema.pageId;
 
     // 入库
@@ -313,9 +334,20 @@ export class SurveyResponseController {
       surveyId: responseSchema.pageId,
       optionTextAndId,
       channelId: params.channelId,
+      autoSubmit,
     };
     const surveyResponse =
       await this.surveyResponseService.createSurveyResponse(model);
+
+    if (autoSubmit) {
+      this.logger.info(
+        `autoSubmit: ${JSON.stringify({
+          event: 'autoSubmit',
+          surveyPath,
+          responseId: surveyResponse?._id?.toString?.() ?? null,
+        })}`,
+      );
+    }
 
     if (canPush) {
       const sendData = getPushingData({

--- a/server/src/modules/surveyResponse/services/surveyResponse.service.ts
+++ b/server/src/modules/surveyResponse/services/surveyResponse.service.ts
@@ -18,6 +18,7 @@ export class SurveyResponseService {
     surveyPath,
     optionTextAndId,
     channelId = undefined,
+    autoSubmit = false,
   }) {
     const newSubmitData = this.surveyResponseRepository.create({
       surveyPath,
@@ -28,6 +29,7 @@ export class SurveyResponseService {
       pageId: surveyId,
       optionTextAndId,
       channelId,
+      autoSubmit: autoSubmit === true,
     });
 
     // 提交问卷

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,8 @@
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "build-only": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "format": "prettier --write src/"
@@ -51,11 +53,13 @@
     "@vitejs/plugin-vue-jsx": "^3.1.0",
     "@vue/eslint-config-prettier": "^8.0.0",
     "@vue/eslint-config-typescript": "^12.0.0",
+    "@vue/test-utils": "^2.4.11",
     "@vue/tsconfig": "^0.5.1",
     "eslint": "^8.49.0",
     "eslint-plugin-vue": "^9.17.0",
     "fs-extra": "^11.2.0",
     "husky": "^9.0.11",
+    "jsdom": "^24.1.3",
     "npm-run-all2": "^6.1.1",
     "prettier": "^3.0.3",
     "sass": "1.79.6",
@@ -65,6 +69,7 @@
     "unplugin-vue-components": "^0.26.0",
     "vite": "^5.1.4",
     "vite-plugin-virtual-mpa": "^1.11.0",
+    "vitest": "^1.6.1",
     "vue-tsc": "^1.8.27"
   },
   "husky": {

--- a/web/src/management/pages/edit/setterConfig/baseConfig.js
+++ b/web/src/management/pages/edit/setterConfig/baseConfig.js
@@ -2,7 +2,12 @@ export default [
   {
     title: '时间配置',
     key: 'timeConfig',
-    formList: ['base_effectTime', 'limit_answerTime']
+    formList: [
+      'base_effectTime',
+      'limit_answerTime',
+      'limit_answerTimeLimit',
+      'limit_answerMinDuration'
+    ]
   },
   {
     title: '提交限制',

--- a/web/src/management/pages/edit/setterConfig/baseFormConfig.js
+++ b/web/src/management/pages/edit/setterConfig/baseFormConfig.js
@@ -22,6 +22,40 @@ export default {
     type: 'QuestionTimeHour',
     placement: 'top'
   },
+  limit_answerTimeLimit: {
+    key: 'answerTimeLimit',
+    label: '答题限时',
+    tip: '问卷必须在规定时间内填完，超时自动提交。',
+    tipShow: true,
+    placement: 'top',
+    type: 'TimeLimitConfig',
+    defaultDuration: 30,
+    valueGetter: ({ moduleConfig }) => {
+      const v = moduleConfig?.answerTimeLimit
+      return {
+        enabled: !!v?.enabled,
+        duration: typeof v?.duration === 'number' && v.duration > 0 ? v.duration : 30,
+        unit: v?.unit === 'second' ? 'second' : 'minute'
+      }
+    }
+  },
+  limit_answerMinDuration: {
+    key: 'answerMinDuration',
+    label: '最短答题时长',
+    tip: '问卷仅可在所设置的时间之后才能进行提交。',
+    tipShow: true,
+    placement: 'top',
+    type: 'TimeLimitConfig',
+    defaultDuration: 10,
+    valueGetter: ({ moduleConfig }) => {
+      const v = moduleConfig?.answerMinDuration
+      return {
+        enabled: !!v?.enabled,
+        duration: typeof v?.duration === 'number' && v.duration > 0 ? v.duration : 10,
+        unit: v?.unit === 'minute' ? 'minute' : 'second'
+      }
+    }
+  },
   limit_fillAnswer: {
     key: 'fillAnswer',
     label: '允许断点续答',

--- a/web/src/management/stores/composables/useInitializeSchema.ts
+++ b/web/src/management/stores/composables/useInitializeSchema.ts
@@ -25,13 +25,14 @@ export default function useInitializeSchema(
 
   function initSchema({ metaData, codeData }: { metaData: any; codeData: any }) {
     schema.metaData = metaData
-    schema.bannerConf = merge({}, schema.bannerConf, codeData.bannerConf)
-    schema.bottomConf = merge({}, schema.bottomConf, codeData.bottomConf)
-    schema.skinConf = merge({}, schema.skinConf, codeData.skinConf)
-    schema.baseConf = merge({}, schema.baseConf, codeData.baseConf)
+    // 基于全新对象合并，避免 Pinia 单例下 schema.* 残留上一份问卷的配置跨问卷泄漏
+    schema.bannerConf = merge({}, codeData.bannerConf)
+    schema.bottomConf = merge({}, codeData.bottomConf)
+    schema.skinConf = merge({}, codeData.skinConf)
+    schema.baseConf = merge({}, codeData.baseConf)
     schema.logicConf = codeData.logicConf
     schema.pageConf = codeData.pageConf
-    schema.submitConf = merge({}, schema.submitConf, codeData.submitConf)
+    schema.submitConf = merge({}, codeData.submitConf)
     schema.questionDataList = codeData.questionDataList || []
     schema.pageEditOne = 1
   }

--- a/web/src/materials/setters/widgets/TimeLimitConfig.vue
+++ b/web/src/materials/setters/widgets/TimeLimitConfig.vue
@@ -54,10 +54,6 @@ interface Emit {
 
 const DEFAULT_DURATION = 30
 const MAX_MINUTE = 1440
-const MIN_SECOND = 0
-
-const ERR_INVALID = '请输入数值'
-
 const props = defineProps<Props>()
 const emit = defineEmits<Emit>()
 
@@ -97,18 +93,8 @@ const unit = ref<Unit>(initial.unit)
 const errorMsg = ref<string>('')
 
 
-const validate = (): boolean => {
-  if (!enabled.value) {
-    errorMsg.value = ''
-    return true
-  }
-  errorMsg.value = ''
-  return true
-}
-
-// 校验通过才 emit（写入 store / 触发自动保存）；不通过则阻断保存并提示
 const commit = () => {
-  if (!validate()) return
+  errorMsg.value = ''
   emit(FORM_CHANGE_EVENT_KEY, {
     key: props.formConfig.key,
     value: {
@@ -164,7 +150,7 @@ watch(
 )
 
 const displayUnitLabel = computed(() => (unit.value === 'second' ? '秒' : '分'))
-defineExpose({ displayUnitLabel, validate, errorMsg })
+defineExpose({ displayUnitLabel, errorMsg })
 </script>
 <style lang="scss" scoped>
 .time-limit-config {

--- a/web/src/materials/setters/widgets/TimeLimitConfig.vue
+++ b/web/src/materials/setters/widgets/TimeLimitConfig.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="time-limit-config">
+    <div class="row">
+      <el-switch v-model="enabled" @change="handleEnabledChange" />
+      <template v-if="enabled">
+        <el-input-number
+          class="duration-input"
+          :class="{ 'is-error': !!errorMsg }"
+          v-model="duration"
+          :controls="false"
+          :min="1"
+          :max="unit === 'minute' ? maxMinute : undefined"
+          :step="1"
+          :precision="0"
+          placeholder="请输入"
+          @blur="handleDurationBlur"
+        />
+        <el-select class="unit-select" v-model="unit" @change="handleUnitChange">
+          <el-option label="分" value="minute" />
+          <el-option label="秒" value="second" />
+        </el-select>
+      </template>
+    </div>
+    <div v-if="enabled && errorMsg" class="error-tip">{{ errorMsg }}</div>
+  </div>
+</template>
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+import { FORM_CHANGE_EVENT_KEY } from '@/materials/setters/constant'
+
+type Unit = 'minute' | 'second'
+
+interface TimeLimitValue {
+  enabled: boolean
+  duration: number
+  unit: Unit
+}
+
+interface FormConfig {
+  key: string
+  value?: TimeLimitValue
+  defaultDuration?: number
+}
+
+interface Props {
+  formConfig: FormConfig
+  moduleConfig: any
+}
+
+interface Emit {
+  (ev: typeof FORM_CHANGE_EVENT_KEY, arg: { key: string; value: TimeLimitValue }): void
+}
+
+const DEFAULT_DURATION = 30
+const MAX_MINUTE = 1440
+const MIN_SECOND = 0
+
+const ERR_INVALID = '请输入数值'
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emit>()
+
+const maxMinute = MAX_MINUTE
+
+// 回退值优先取 setter 声明的 defaultDuration（answerMinDuration=10 / answerTimeLimit=30），缺省回退 30
+const fallbackDuration = computed<number>(() =>
+  typeof props.formConfig.defaultDuration === 'number' && props.formConfig.defaultDuration > 0
+    ? Math.floor(props.formConfig.defaultDuration)
+    : DEFAULT_DURATION
+)
+
+const normalizeUnit = (u: any): Unit => (u === 'second' ? 'second' : 'minute')
+
+const seedFromValue = (v: TimeLimitValue | undefined): TimeLimitValue => {
+  const base: TimeLimitValue = {
+    enabled: false,
+    duration: fallbackDuration.value,
+    unit: 'minute'
+  }
+  if (!v || typeof v !== 'object') return base
+  return {
+    enabled: !!v.enabled,
+    duration:
+      typeof v.duration === 'number' && Number.isFinite(v.duration) && v.duration > 0
+        ? Math.floor(v.duration)
+        : fallbackDuration.value,
+    unit: normalizeUnit(v.unit)
+  }
+}
+
+const initial = seedFromValue(props.formConfig.value)
+const enabled = ref<boolean>(initial.enabled)
+// duration 允许空态（null）：用户清空输入框时为非法态，阻断写库等待重新输入
+const duration = ref<number | null>(initial.duration)
+const unit = ref<Unit>(initial.unit)
+const errorMsg = ref<string>('')
+
+
+const validate = (): boolean => {
+  if (!enabled.value) {
+    errorMsg.value = ''
+    return true
+  }
+  errorMsg.value = ''
+  return true
+}
+
+// 校验通过才 emit（写入 store / 触发自动保存）；不通过则阻断保存并提示
+const commit = () => {
+  if (!validate()) return
+  emit(FORM_CHANGE_EVENT_KEY, {
+    key: props.formConfig.key,
+    value: {
+      enabled: enabled.value,
+      duration: duration.value as number,
+      unit: unit.value
+    }
+  })
+}
+
+const handleEnabledChange = () => {
+  if (!enabled.value) {
+    errorMsg.value = ''
+    emit(FORM_CHANGE_EVENT_KEY, {
+      key: props.formConfig.key,
+      value: {
+        enabled: false,
+        duration: (duration.value as number) || fallbackDuration.value,
+        unit: unit.value
+      }
+    })
+    return
+  }
+  commit()
+}
+
+const handleDurationBlur = () => {
+  commit()
+}
+
+const handleUnitChange = (next: Unit) => {
+  unit.value = next
+  commit()
+}
+
+// 当父 schema 外部变化（如远端拉到的回显）时同步本地
+watch(
+  () => props.formConfig.value,
+  (newVal) => {
+    const seeded = seedFromValue(newVal)
+    if (
+      seeded.enabled !== enabled.value ||
+      seeded.duration !== duration.value ||
+      seeded.unit !== unit.value
+    ) {
+      enabled.value = seeded.enabled
+      duration.value = seeded.duration
+      unit.value = seeded.unit
+      errorMsg.value = ''
+    }
+  },
+  { deep: true }
+)
+
+const displayUnitLabel = computed(() => (unit.value === 'second' ? '秒' : '分'))
+defineExpose({ displayUnitLabel, validate, errorMsg })
+</script>
+<style lang="scss" scoped>
+.time-limit-config {
+  display: flex;
+  flex-direction: column;
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .duration-input {
+    width: 110px;
+
+    &.is-error :deep(.el-input__wrapper) {
+      box-shadow: 0 0 0 1px var(--el-color-danger) inset;
+    }
+  }
+
+  .unit-select {
+    width: 80px;
+  }
+
+  .error-tip {
+    margin-top: 4px;
+    color: var(--el-color-danger, #f56c6c);
+    font-size: 12px;
+    line-height: 1.4;
+  }
+}
+</style>

--- a/web/src/materials/setters/widgets/__tests__/TimeLimitConfig.spec.ts
+++ b/web/src/materials/setters/widgets/__tests__/TimeLimitConfig.spec.ts
@@ -64,13 +64,18 @@ describe('TimeLimitConfig — 切换单位保留原值、不提示（SUR-37 反�
     })
   })
 
-  it('空态 blur 不会自动回退（保持空 + 报错 + 不落库）', async () => {
+  it('空态 blur 不再在保存侧 validate，按当前值向上 emit', async () => {
     const w = factory(limitConf())
     ;(w.vm as any).duration = null
     ;(w.vm as any).handleDurationBlur()
     expect((w.vm as any).duration).toBeNull()
-    expect((w.vm as any).errorMsg).toBeTruthy()
-    expect(emittedOf(w).length).toBe(0)
+    expect((w.vm as any).errorMsg).toBe('')
+    const emitted = emittedOf(w)
+    expect(emitted.length).toBe(1)
+    expect(emitted[0][0]).toMatchObject({
+      key: 'answerTimeLimit',
+      value: { enabled: true, duration: null, unit: 'minute' }
+    })
   })
 })
 

--- a/web/src/materials/setters/widgets/__tests__/TimeLimitConfig.spec.ts
+++ b/web/src/materials/setters/widgets/__tests__/TimeLimitConfig.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import TimeLimitConfig from '../TimeLimitConfig.vue'
+
+// element-plus 的 ElMessage 在 jsdom 下需要 mock，避免真实挂载
+vi.mock('element-plus', () => ({
+  ElMessage: { warning: vi.fn() }
+}))
+vi.mock('element-plus/theme-chalk/src/base.scss', () => ({}))
+vi.mock('element-plus/theme-chalk/src/message.scss', () => ({}))
+
+const FORM_CHANGE = 'form-change'
+
+const factory = (formConfig: any, moduleConfig: any = {}) =>
+  mount(TimeLimitConfig, {
+    props: { formConfig, moduleConfig },
+    global: {
+      stubs: {
+        'el-switch': true,
+        'el-input-number': true,
+        'el-select': true,
+        'el-option': true
+      }
+    }
+  })
+
+const limitConf = (over: any = {}) => ({
+  key: 'answerTimeLimit',
+  value: { enabled: true, duration: 30, unit: 'minute', ...over }
+})
+
+const emittedOf = (w: any) => (w.emitted()[FORM_CHANGE] || []) as any[]
+
+describe('TimeLimitConfig — 默认值（defaultDuration 回退）', () => {
+  it('answerMinDuration 无值时按 defaultDuration=10 回退（不再固定 30）', async () => {
+    const w = factory({ key: 'answerMinDuration', defaultDuration: 10 })
+    expect((w.vm as any).duration).toBe(10)
+  })
+
+  it('未声明 defaultDuration 时回退到 30', async () => {
+    const w = factory({ key: 'answerTimeLimit' })
+    expect((w.vm as any).duration).toBe(30)
+  })
+})
+
+describe('TimeLimitConfig — 切换单位保留原值、不提示（SUR-37 反转 CL-018）', () => {
+  it('切换单位时 duration 保持原值不变', async () => {
+    const w = factory(limitConf())
+    expect((w.vm as any).duration).toBe(30)
+    ;(w.vm as any).handleUnitChange('second')
+    expect((w.vm as any).duration).toBe(30)
+  })
+
+  it('切换单位后校验通过即向上 emit（携带原数值 + 新单位）', async () => {
+    const w = factory(limitConf())
+    ;(w.vm as any).handleUnitChange('second')
+    expect((w.vm as any).errorMsg).toBe('')
+    const emitted = emittedOf(w)
+    expect(emitted.length).toBe(1)
+    expect(emitted[0][0]).toMatchObject({
+      key: 'answerTimeLimit',
+      value: { enabled: true, duration: 30, unit: 'second' }
+    })
+  })
+
+  it('空态 blur 不会自动回退（保持空 + 报错 + 不落库）', async () => {
+    const w = factory(limitConf())
+    ;(w.vm as any).duration = null
+    ;(w.vm as any).handleDurationBlur()
+    expect((w.vm as any).duration).toBeNull()
+    expect((w.vm as any).errorMsg).toBeTruthy()
+    expect(emittedOf(w).length).toBe(0)
+  })
+})
+
+describe('TimeLimitConfig — 最短时长与限时关系不阻断保存（2026-07-17）', () => {
+  it('最短时长 ≥ 答题限时（同单位）仍通过并 emit', async () => {
+    const w = factory(
+      { key: 'answerMinDuration', value: { enabled: true, duration: 30, unit: 'minute' } },
+      { answerTimeLimit: { enabled: true, duration: 30, unit: 'minute' } }
+    )
+    ;(w.vm as any).handleDurationBlur()
+    expect((w.vm as any).errorMsg).toBe('')
+    expect(emittedOf(w).length).toBe(1)
+  })
+
+  it('跨单位归一化后最短时长大于限时，也不报跨字段错误', async () => {
+    const w = factory(
+      { key: 'answerMinDuration', value: { enabled: true, duration: 2, unit: 'minute' } },
+      { answerTimeLimit: { enabled: true, duration: 30, unit: 'second' } }
+    )
+    ;(w.vm as any).handleDurationBlur()
+    expect((w.vm as any).errorMsg).toBe('')
+    expect(emittedOf(w).length).toBe(1)
+  })
+
+  it('从限时侧编辑：限时 ≤ 最短 时仍通过并 emit', async () => {
+    const w = factory(
+      { key: 'answerTimeLimit', value: { enabled: true, duration: 10, unit: 'minute' } },
+      { answerMinDuration: { enabled: true, duration: 10, unit: 'minute' } }
+    )
+    ;(w.vm as any).handleDurationBlur()
+    expect((w.vm as any).errorMsg).toBe('')
+    expect(emittedOf(w).length).toBe(1)
+  })
+})

--- a/web/src/render/__tests__/AnswerTimeLimitDialog.spec.ts
+++ b/web/src/render/__tests__/AnswerTimeLimitDialog.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AnswerTimeLimitDialog from '../components/AnswerTimeLimitDialog.vue'
+
+const factory = (props: Record<string, unknown>) =>
+  mount(AnswerTimeLimitDialog, {
+    props: {
+      visible: true,
+      duration: 30,
+      unit: 'minute',
+      remainingMs: 30 * 60 * 1000,
+      ...props
+    }
+  })
+
+describe('AnswerTimeLimitDialog (CL-012 / CL-015)', () => {
+  describe('minute unit', () => {
+    it('shows X=Y copy when remaining equals total', () => {
+      const wrapper = factory({
+        duration: 30,
+        unit: 'minute',
+        remainingMs: 30 * 60 * 1000
+      })
+      const text = wrapper.find('.content').text()
+      expect(text).toContain('本次问卷填写限时 30 分钟')
+      expect(text).not.toContain('剩余答题时长')
+    })
+
+    it('shows X=Y copy when remainingMs > totalMs (defensive)', () => {
+      const wrapper = factory({
+        duration: 30,
+        unit: 'minute',
+        remainingMs: 31 * 60 * 1000
+      })
+      expect(wrapper.find('.content').text()).not.toContain('剩余答题时长')
+    })
+
+    it('shows X<Y copy when 1min ≤ remaining < total', () => {
+      const wrapper = factory({
+        duration: 30,
+        unit: 'minute',
+        remainingMs: 5 * 60 * 1000
+      })
+      const text = wrapper.find('.content').text()
+      expect(text).toContain('限时 30 分钟')
+      expect(text).toContain('剩余答题时长 5 分钟')
+    })
+
+    it('shows X<1min copy when remaining < 60s in minute mode', () => {
+      const wrapper = factory({
+        duration: 30,
+        unit: 'minute',
+        remainingMs: 30 * 1000
+      })
+      const text = wrapper.find('.content').text()
+      expect(text).toContain('剩余答题时长不足 1 分钟')
+    })
+  })
+
+  describe('second unit (CL-015 — no <1sec branch)', () => {
+    it('shows X=Y copy when remaining equals total in seconds', () => {
+      const wrapper = factory({
+        duration: 60,
+        unit: 'second',
+        remainingMs: 60 * 1000
+      })
+      const text = wrapper.find('.content').text()
+      expect(text).toContain('限时 60 秒')
+      expect(text).not.toContain('剩余答题时长')
+    })
+
+    it('shows X<Y copy with seconds remaining', () => {
+      const wrapper = factory({
+        duration: 60,
+        unit: 'second',
+        remainingMs: 25 * 1000
+      })
+      const text = wrapper.find('.content').text()
+      expect(text).toContain('限时 60 秒')
+      expect(text).toContain('剩余答题时长 25 秒')
+    })
+
+    it('does NOT use the <1 minute branch for sub-second remaining', () => {
+      const wrapper = factory({
+        duration: 60,
+        unit: 'second',
+        remainingMs: 500
+      })
+      const text = wrapper.find('.content').text()
+      expect(text).not.toContain('不足 1 分钟')
+      expect(text).toContain('秒')
+    })
+  })
+
+  describe('handleStart', () => {
+    it('emits start then close on click', async () => {
+      const wrapper = factory({})
+      await wrapper.find('.btn-dark').trigger('click')
+      expect(wrapper.emitted('start')).toBeTruthy()
+      expect(wrapper.emitted('close')).toBeTruthy()
+    })
+  })
+
+  describe('visibility', () => {
+    it('does not render mask when visible=false', () => {
+      const wrapper = factory({ visible: false })
+      expect(wrapper.find('.mask').exists()).toBe(false)
+    })
+  })
+})

--- a/web/src/render/__tests__/CountdownHeader.spec.ts
+++ b/web/src/render/__tests__/CountdownHeader.spec.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import CountdownHeader from '../components/CountdownHeader.vue'
+
+const FIXED_NOW = 1_700_000_000_000
+
+describe('CountdownHeader (CL-013 / CL-014)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('display format', () => {
+    it('shows mm:ss in minute mode', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 30,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 30 * 60 * 1000,
+          active: true
+        }
+      })
+      expect(wrapper.text()).toBe('倒计时 30:00')
+    })
+
+    it('shows ss only in second mode', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 45,
+          unit: 'second',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 45 * 1000,
+          active: true
+        }
+      })
+      expect(wrapper.text()).toBe('倒计时 45')
+    })
+
+    it('uses 3-digit minutes when total ≥100 minutes', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 120,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 120 * 60 * 1000,
+          active: true
+        }
+      })
+      expect(wrapper.text()).toBe('倒计时 120:00')
+    })
+
+    it('zero-pads single-digit minutes/seconds', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 5,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 5 * 60 * 1000 + 9 * 1000,
+          active: true
+        }
+      })
+      expect(wrapper.text()).toBe('倒计时 05:09')
+    })
+
+    it('renders nothing when not active', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 30,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 30 * 60 * 1000,
+          active: false
+        }
+      })
+      expect(wrapper.find('.countdown-header').exists()).toBe(false)
+    })
+  })
+
+  describe('tick / expire', () => {
+    it('emits tick on every interval', async () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 1,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 60 * 1000,
+          active: true
+        }
+      })
+      vi.setSystemTime(FIXED_NOW + 1000)
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+      const ticks = wrapper.emitted('tick')
+      expect(ticks).toBeTruthy()
+      expect(ticks!.length).toBeGreaterThan(0)
+    })
+
+    it('emits expire when remaining reaches 0', async () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 1,
+          unit: 'second',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 1000,
+          active: true
+        }
+      })
+      vi.setSystemTime(FIXED_NOW + 1000)
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+      expect(wrapper.emitted('expire')).toBeTruthy()
+    })
+
+    it('emits expire immediately on mount when initial already 0', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 1,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 0,
+          active: true
+        }
+      })
+      expect(wrapper.emitted('expire')).toBeTruthy()
+    })
+  })
+
+  describe('warn class', () => {
+    it('applies is-warn when remainingSec ≤ 30', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 30,
+          unit: 'second',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 30 * 1000,
+          active: true
+        }
+      })
+      expect(wrapper.find('.countdown-header').classes()).toContain('is-warn')
+    })
+
+    it('does not apply is-warn when remainingSec > 30', () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 5,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 5 * 60 * 1000,
+          active: true
+        }
+      })
+      expect(wrapper.find('.countdown-header').classes()).not.toContain('is-warn')
+    })
+  })
+
+  describe('visibilitychange recalibration', () => {
+    it('recalculates remaining via real time when tab becomes visible (expire path)', async () => {
+      const wrapper = mount(CountdownHeader, {
+        props: {
+          duration: 1,
+          unit: 'minute',
+          startedAt: FIXED_NOW,
+          initialRemainingMs: 60 * 1000,
+          active: true
+        }
+      })
+      // 模拟切到后台 90s 后回到前台（已超时）
+      vi.setSystemTime(FIXED_NOW + 90 * 1000)
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'visible'
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+      await flushPromises()
+      expect(wrapper.emitted('expire')).toBeTruthy()
+    })
+  })
+})

--- a/web/src/render/__tests__/README.md
+++ b/web/src/render/__tests__/README.md
@@ -1,0 +1,35 @@
+# C 端单测（SUR-29 / answer-time-limit）
+
+QA / 本地开发自跑：
+
+```bash
+cd web
+npm i -D vitest@^1 @vue/test-utils@^2 jsdom@^24
+cat > vitest.config.ts <<'EOF'
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@render': fileURLToPath(new URL('./src/render', import.meta.url))
+    }
+  },
+  test: { environment: 'jsdom', include: ['src/**/__tests__/*.spec.ts'] }
+})
+EOF
+npx vitest run
+```
+
+预期：3 个 spec 文件 / 32 个用例全部通过。
+
+| Spec | 用例 | 覆盖 |
+|------|------|------|
+| `answerTimeStore.spec.ts` | 12 | T-FE-R-01 / FR-036 / C-009 |
+| `AnswerTimeLimitDialog.spec.ts` | 9 | T-FE-R-02 / CL-012 / CL-015 |
+| `CountdownHeader.spec.ts` | 11 | T-FE-R-03 / CL-013 / visibilitychange 校准 |
+
+> `vitest.config.ts` 不入仓避免污染 `tsc` 扫描（vitest 非生产依赖）；按上述命令一次性生成即可。

--- a/web/src/render/__tests__/answerMinDurationEffective.spec.ts
+++ b/web/src/render/__tests__/answerMinDurationEffective.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+
+import { type AnswerTimeLimitConf, getEffectiveAnswerMinDuration } from '../types/answerTimeLimit'
+
+const conf = (
+  duration: number,
+  unit: AnswerTimeLimitConf['unit'] = 'minute'
+): AnswerTimeLimitConf => ({
+  enabled: true,
+  duration,
+  unit
+})
+
+describe('C-end answerMinDuration runtime effectiveness', () => {
+  it('treats min duration as not effective when min is equal to answer time limit', () => {
+    expect(getEffectiveAnswerMinDuration(conf(1), conf(1))).toBeNull()
+  })
+
+  it('treats min duration as not effective when min is greater than answer time limit', () => {
+    expect(getEffectiveAnswerMinDuration(conf(5), conf(1))).toBeNull()
+  })
+
+  it('normalizes units before comparing min duration and answer time limit', () => {
+    expect(getEffectiveAnswerMinDuration(conf(2, 'minute'), conf(30, 'second'))).toBeNull()
+  })
+
+  it('keeps min duration effective when it is less than answer time limit', () => {
+    const min = conf(5)
+    expect(getEffectiveAnswerMinDuration(min, conf(30))).toBe(min)
+  })
+
+  it('keeps min duration effective when only min duration is enabled', () => {
+    const min = conf(5)
+    expect(getEffectiveAnswerMinDuration(min, null)).toBe(min)
+  })
+})

--- a/web/src/render/__tests__/answerMinDurationEffective.spec.ts
+++ b/web/src/render/__tests__/answerMinDurationEffective.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 
-import { type AnswerTimeLimitConf, getEffectiveAnswerMinDuration } from '../types/answerTimeLimit'
+import {
+  type AnswerTimeLimitConf,
+  getEffectiveAnswerMinDuration,
+  normalizeAnswerTimeConf
+} from '../types/answerTimeLimit'
 
 const conf = (
   duration: number,
@@ -32,5 +36,37 @@ describe('C-end answerMinDuration runtime effectiveness', () => {
   it('keeps min duration effective when only min duration is enabled', () => {
     const min = conf(5)
     expect(getEffectiveAnswerMinDuration(min, null)).toBe(min)
+  })
+})
+
+describe('C-end answer time config validation', () => {
+  it('does not apply enabled config with invalid duration', () => {
+    expect(
+      normalizeAnswerTimeConf({ enabled: true, duration: null, unit: 'minute' })
+    ).toBeNull()
+    expect(
+      normalizeAnswerTimeConf({ enabled: true, duration: 1.5, unit: 'minute' })
+    ).toBeNull()
+  })
+
+  it('does not apply enabled config outside runtime bounds', () => {
+    expect(
+      normalizeAnswerTimeConf({ enabled: true, duration: 1441, unit: 'minute' })
+    ).toBeNull()
+    expect(
+      normalizeAnswerTimeConf({ enabled: true, duration: 9, unit: 'second' })
+    ).toBeNull()
+  })
+
+  it('does not apply config with invalid unit instead of defaulting it', () => {
+    expect(
+      normalizeAnswerTimeConf({ enabled: true, duration: 30, unit: 'hour' })
+    ).toBeNull()
+  })
+
+  it('keeps valid enabled config as-is', () => {
+    expect(
+      normalizeAnswerTimeConf({ enabled: true, duration: 30, unit: 'minute' })
+    ).toEqual({ enabled: true, duration: 30, unit: 'minute' })
   })
 })

--- a/web/src/render/__tests__/answerTimeStore.spec.ts
+++ b/web/src/render/__tests__/answerTimeStore.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  read,
+  write,
+  clear,
+  init,
+  ANSWER_TIME_KEY_PREFIX
+} from '../utils/answerTimeStore'
+
+const FIXED_NOW = 1_700_000_000_000
+
+describe('answerTimeStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('write / read', () => {
+    it('writes record under survey-engine:answer-time:{surveyPath}', () => {
+      write({
+        surveyPath: 'abcd1234',
+        remainingMs: 600000,
+        startedAt: FIXED_NOW,
+        duration: 30,
+        unit: 'minute',
+        updatedAt: FIXED_NOW
+      })
+      const raw = localStorage.getItem(`${ANSWER_TIME_KEY_PREFIX}abcd1234`)
+      expect(raw).toBeTruthy()
+      const parsed = JSON.parse(raw!)
+      expect(parsed.remainingMs).toBe(600000)
+      expect(parsed.unit).toBe('minute')
+    })
+
+    it('reads back what was written', () => {
+      write({
+        surveyPath: 'pathA',
+        remainingMs: 120000,
+        startedAt: FIXED_NOW,
+        duration: 2,
+        unit: 'minute',
+        updatedAt: FIXED_NOW
+      })
+      const r = read('pathA')
+      expect(r).not.toBeNull()
+      expect(r!.remainingMs).toBe(120000)
+      expect(r!.duration).toBe(2)
+      expect(r!.unit).toBe('minute')
+    })
+
+    it('returns null on miss', () => {
+      expect(read('does-not-exist')).toBeNull()
+    })
+
+    it('returns null on corrupt payload', () => {
+      localStorage.setItem(`${ANSWER_TIME_KEY_PREFIX}bad`, '{not json')
+      expect(read('bad')).toBeNull()
+    })
+
+    it('isolates records across surveyPaths', () => {
+      write({
+        surveyPath: 'A',
+        remainingMs: 1000,
+        startedAt: FIXED_NOW,
+        duration: 1,
+        unit: 'second',
+        updatedAt: FIXED_NOW
+      })
+      write({
+        surveyPath: 'B',
+        remainingMs: 60000,
+        startedAt: FIXED_NOW,
+        duration: 1,
+        unit: 'minute',
+        updatedAt: FIXED_NOW
+      })
+      expect(read('A')!.remainingMs).toBe(1000)
+      expect(read('B')!.remainingMs).toBe(60000)
+    })
+  })
+
+  describe('clear', () => {
+    it('removes the record for a given surveyPath', () => {
+      write({
+        surveyPath: 'gone',
+        remainingMs: 1,
+        startedAt: 0,
+        duration: 1,
+        unit: 'minute',
+        updatedAt: 0
+      })
+      clear('gone')
+      expect(read('gone')).toBeNull()
+    })
+
+    it('does not error when clearing missing key', () => {
+      expect(() => clear('never-existed')).not.toThrow()
+    })
+  })
+
+  describe('init', () => {
+    it('returns null when conf disabled', () => {
+      expect(init('p', { enabled: false, duration: 30, unit: 'minute' })).toBeNull()
+      expect(init('p', null)).toBeNull()
+    })
+
+    it('initializes a fresh record using duration × unit', () => {
+      const rec = init('fresh', { enabled: true, duration: 30, unit: 'minute' })
+      expect(rec).not.toBeNull()
+      expect(rec!.remainingMs).toBe(30 * 60 * 1000)
+      expect(rec!.unit).toBe('minute')
+      expect(read('fresh')!.remainingMs).toBe(30 * 60 * 1000)
+    })
+
+    it('initializes seconds correctly', () => {
+      const rec = init('s', { enabled: true, duration: 45, unit: 'second' })
+      expect(rec!.remainingMs).toBe(45 * 1000)
+    })
+
+    it('preserves existing record when conf matches', () => {
+      write({
+        surveyPath: 'keep',
+        remainingMs: 50000,
+        startedAt: FIXED_NOW,
+        duration: 30,
+        unit: 'minute',
+        updatedAt: FIXED_NOW
+      })
+      const rec = init('keep', { enabled: true, duration: 30, unit: 'minute' })
+      expect(rec!.remainingMs).toBe(50000)
+    })
+
+    it('resets when conf duration / unit changed (B 端改配置后)', () => {
+      write({
+        surveyPath: 'reset',
+        remainingMs: 50000,
+        startedAt: FIXED_NOW,
+        duration: 30,
+        unit: 'minute',
+        updatedAt: FIXED_NOW
+      })
+      const rec = init('reset', { enabled: true, duration: 60, unit: 'minute' })
+      expect(rec!.duration).toBe(60)
+      expect(rec!.remainingMs).toBe(60 * 60 * 1000)
+    })
+  })
+})

--- a/web/src/render/components/AnswerTimeLimitDialog.vue
+++ b/web/src/render/components/AnswerTimeLimitDialog.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="mask" v-if="visible">
+    <div class="box">
+      <div class="title">提示</div>
+      <div class="content">{{ message }}</div>
+      <div class="btn btn-dark btn-base" @click="handleStart">开始填写</div>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { AnswerTimeUnit } from '../types/answerTimeLimit'
+
+interface Props {
+  visible?: boolean
+  /** B 端配置的总限时（duration） */
+  duration: number
+  /** 单位：分 / 秒 */
+  unit: AnswerTimeUnit
+  /** 剩余答题时长（ms） */
+  remainingMs: number
+}
+
+interface Emit {
+  (ev: 'start'): void
+  (ev: 'close'): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  visible: false
+})
+
+const emit = defineEmits<Emit>()
+
+const unitLabel = computed(() => (props.unit === 'second' ? '秒' : '分钟'))
+
+const totalMs = computed(() =>
+  props.unit === 'second' ? props.duration * 1000 : props.duration * 60 * 1000
+)
+
+const message = computed(() => {
+  const Y = props.duration
+  const remaining = props.remainingMs
+  // 首次进入：剩余等于总时长（或 ≥ 总时长）
+  if (remaining >= totalMs.value) {
+    return `本次问卷填写限时 ${Y} ${unitLabel.value}，开始填写后计时，超时将自动提交`
+  }
+  if (props.unit === 'minute') {
+    if (remaining < 60 * 1000) {
+      return `本次问卷填写限时 ${Y} 分钟，本次剩余答题时长不足 1 分钟，开始填写后计时，超时将自动提交`
+    }
+    const remainingMinutes = Math.floor(remaining / 60000)
+    return `本次问卷填写限时 ${Y} 分钟，本次剩余答题时长 ${remainingMinutes} 分钟，开始填写后计时，超时将自动提交`
+  }
+  // unit === 'second' — 无「不足 1 秒」分支（CL-015）
+  const remainingSeconds = Math.max(0, Math.floor(remaining / 1000))
+  return `本次问卷填写限时 ${Y} 秒，本次剩余答题时长 ${remainingSeconds} 秒，开始填写后计时，超时将自动提交`
+})
+
+const handleStart = () => {
+  emit('start')
+  emit('close')
+}
+</script>
+<style lang="scss" scoped>
+@import url('../styles/dialog.scss');
+
+.mask {
+  z-index: 1000;
+}
+
+.btn-dark {
+  background: #4a4c5b;
+  color: #fff;
+}
+
+.content {
+  font-size: 0.26rem;
+  color: #606266;
+  line-height: 1.6;
+  text-align: center;
+  margin: 0.32rem 0 0.4rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.btn-base {
+  margin-top: 0.4rem;
+}
+</style>

--- a/web/src/render/components/CountdownHeader.vue
+++ b/web/src/render/components/CountdownHeader.vue
@@ -1,0 +1,135 @@
+<template>
+  <div v-if="active" class="countdown-header" :class="{ 'is-warn': remainingSec <= warnThreshold }">
+    {{ display }}
+  </div>
+</template>
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import type { AnswerTimeUnit } from '../types/answerTimeLimit'
+
+interface Props {
+  /** 总时长（duration） */
+  duration: number
+  unit: AnswerTimeUnit
+  /** 起算时间戳（Date.now() 时刻），0 表示未开始 */
+  startedAt: number
+  /** 起算时已剩余的毫秒数（用于断点续答） */
+  initialRemainingMs: number
+  /** 是否激活（answerTimeLimit.enabled && 已开始填写） */
+  active?: boolean
+}
+
+interface Emit {
+  (ev: 'expire'): void
+  (ev: 'tick', remainingMs: number): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  active: false
+})
+
+const emit = defineEmits<Emit>()
+
+const now = ref(Date.now())
+let timer: number | null = null
+
+const elapsed = computed(() => Math.max(0, now.value - props.startedAt))
+const remainingMs = computed(() => Math.max(0, props.initialRemainingMs - elapsed.value))
+const remainingSec = computed(() => Math.ceil(remainingMs.value / 1000))
+
+const warnThreshold = 30
+
+const pad2 = (n: number) => (n < 10 ? `0${n}` : `${n}`)
+
+const display = computed(() => {
+  if (!props.active) return ''
+  const ms = remainingMs.value
+  if (props.unit === 'second') {
+    const s = Math.max(0, Math.ceil(ms / 1000))
+    return `倒计时 ${s}`
+  }
+  // 分钟模式：mm:ss；≥100 分钟时使用 3 位分钟
+  const totalSec = Math.max(0, Math.ceil(ms / 1000))
+  const minutes = Math.floor(totalSec / 60)
+  const seconds = totalSec - minutes * 60
+  const mm = minutes >= 100 ? String(minutes) : pad2(minutes)
+  return `倒计时 ${mm}:${pad2(seconds)}`
+})
+
+const stopTimer = () => {
+  if (timer != null) {
+    window.clearInterval(timer)
+    timer = null
+  }
+}
+
+const tick = () => {
+  now.value = Date.now()
+  emit('tick', remainingMs.value)
+  if (remainingMs.value <= 0) {
+    stopTimer()
+    emit('expire')
+  }
+}
+
+const startTimer = () => {
+  stopTimer()
+  if (!props.active || props.startedAt <= 0) return
+  now.value = Date.now()
+  if (remainingMs.value <= 0) {
+    emit('expire')
+    return
+  }
+  timer = window.setInterval(tick, 1000)
+}
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === 'visible') {
+    now.value = Date.now()
+    if (props.active && remainingMs.value <= 0) {
+      stopTimer()
+      emit('expire')
+    }
+  }
+}
+
+watch(
+  () => [props.active, props.startedAt],
+  () => {
+    startTimer()
+  }
+)
+
+onMounted(() => {
+  startTimer()
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+})
+
+onBeforeUnmount(() => {
+  stopTimer()
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
+})
+
+defineExpose({ remainingMs })
+</script>
+<style lang="scss" scoped>
+.countdown-header {
+  position: fixed;
+  top: 0.16rem;
+  right: 0.2rem;
+  z-index: 10;
+  padding: 0.08rem 0.24rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 0.26rem;
+  line-height: 1.4;
+  letter-spacing: 0.02rem;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+
+  &.is-warn {
+    background: #f56c6c;
+  }
+}
+</style>

--- a/web/src/render/components/MinDurationDialog.vue
+++ b/web/src/render/components/MinDurationDialog.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="mask" v-if="visible">
+    <div class="box">
+      <div class="message">{{ message }}</div>
+      <div class="btn btn-dark btn-base" @click="handleClose">我知道了</div>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { AnswerTimeUnit } from '../types/answerTimeLimit'
+
+interface Props {
+  visible?: boolean
+  /** B 端配置的 answerMinDuration.duration */
+  duration: number
+  unit: AnswerTimeUnit
+}
+
+interface Emit {
+  (ev: 'close'): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  visible: false
+})
+
+const emit = defineEmits<Emit>()
+
+const message = computed(() => {
+  const unitLabel = props.unit === 'second' ? '秒' : '分钟'
+  return `答题时间不足 ${props.duration} ${unitLabel}，无法提交，请稍后再试！`
+})
+
+const handleClose = () => {
+  emit('close')
+}
+</script>
+<style lang="scss" scoped>
+@import url('../styles/dialog.scss');
+
+.mask {
+  z-index: 1000;
+}
+
+.btn-dark {
+  background: #4a4c5b;
+  color: #fff;
+}
+
+.message {
+  font-size: 0.28rem;
+  color: #4a4c5b;
+  font-weight: 500;
+  line-height: 1.6;
+  text-align: center;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.btn-base {
+  margin-top: 0.4rem;
+}
+</style>

--- a/web/src/render/pages/RenderPage.vue
+++ b/web/src/render/pages/RenderPage.vue
@@ -1,6 +1,32 @@
 <template>
   <div class="index">
     <ProgressBar />
+    <CountdownHeader
+      v-if="answerTimeLimit?.enabled"
+      :duration="answerTimeLimit.duration"
+      :unit="answerTimeLimit.unit"
+      :started-at="startedAt"
+      :initial-remaining-ms="initialRemainingMs"
+      :active="answeringStarted"
+      @expire="handleExpire"
+      @tick="handleTick"
+    />
+    <AnswerTimeLimitDialog
+      v-if="answerTimeLimit?.enabled"
+      :visible="entryDialogVisible"
+      :duration="answerTimeLimit.duration"
+      :unit="answerTimeLimit.unit"
+      :remaining-ms="initialRemainingMs"
+      @start="handleStartAnswering"
+      @close="entryDialogVisible = false"
+    />
+    <MinDurationDialog
+      v-if="effectiveAnswerMinDuration?.enabled"
+      :visible="minDurationDialogVisible"
+      :duration="effectiveAnswerMinDuration.duration"
+      :unit="effectiveAnswerMinDuration.unit"
+      @close="minDurationDialogVisible = false"
+    />
     <div class="wrapper" ref="boxRef">
       <HeaderContent v-if="pageIndex == 1" :bannerConf="bannerConf" :readonly="true" />
       <div class="content">
@@ -21,7 +47,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRouter } from 'vue-router'
 // @ts-ignore
@@ -34,6 +60,9 @@ import ConfirmDialog from '../components/ConfirmDialog.vue'
 import VerifyDialog from '../components/VerifyDialog/index.vue'
 
 import ProgressBar from '../components/ProgressBar.vue'
+import AnswerTimeLimitDialog from '../components/AnswerTimeLimitDialog.vue'
+import CountdownHeader from '../components/CountdownHeader.vue'
+import MinDurationDialog from '../components/MinDurationDialog.vue'
 
 import { useSurveyStore } from '../stores/survey'
 import { useQuestionStore } from '../stores/question'
@@ -45,6 +74,18 @@ import {
   clearSurveySubmit,
   setSurveySubmit
 } from '../utils/storage'
+import {
+  read as readAnswerTime,
+  write as writeAnswerTime,
+  clear as clearAnswerTime,
+  init as initAnswerTime
+} from '../utils/answerTimeStore'
+import {
+  type AnswerTimeLimitConf,
+  getEffectiveAnswerMinDuration,
+  normalizeUnit,
+  unitToMs
+} from '../types/answerTimeLimit'
 
 interface Props {
   questionInfo?: any
@@ -74,19 +115,126 @@ const questionStore = useQuestionStore()
 const renderData = computed(() => questionStore.renderData)
 const isFinallyPage = computed(() => questionStore.isFinallyPage)
 const pageIndex = computed(() => questionStore.pageIndex)
-const { bannerConf, submitConf, bottomConf: logoConf, whiteData } = storeToRefs(surveyStore)
+const {
+  bannerConf,
+  submitConf,
+  bottomConf: logoConf,
+  whiteData,
+  baseConf
+} = storeToRefs(surveyStore)
 const surveyPath = computed(() => surveyStore.surveyPath || '')
 
+// === 答题限时 / 最短答题时长 ===
+const normalizeConf = (raw: any): AnswerTimeLimitConf | null => {
+  if (!raw || typeof raw !== 'object' || raw.enabled !== true) return null
+  const duration = typeof raw.duration === 'number' && raw.duration > 0 ? raw.duration : 30
+  return {
+    enabled: true,
+    duration,
+    unit: normalizeUnit(raw.unit)
+  }
+}
+
+const answerTimeLimit = computed<AnswerTimeLimitConf | null>(() =>
+  normalizeConf((baseConf.value as any)?.answerTimeLimit)
+)
+const answerMinDuration = computed<AnswerTimeLimitConf | null>(() =>
+  normalizeConf((baseConf.value as any)?.answerMinDuration)
+)
+const effectiveAnswerMinDuration = computed<AnswerTimeLimitConf | null>(() =>
+  getEffectiveAnswerMinDuration(answerMinDuration.value, answerTimeLimit.value)
+)
+
+const entryDialogVisible = ref(false)
+const minDurationDialogVisible = ref(false)
+const answeringStarted = ref(false)
+const startedAt = ref(0)
+const initialRemainingMs = ref(0)
+let lastKnownRemainingMs = 0
+const persistTimer = ref<number | null>(null)
+const submitting = ref(false)
+
+const persistRemaining = () => {
+  const conf = answerTimeLimit.value
+  if (!conf || !surveyPath.value || startedAt.value <= 0) return
+  // 优先用倒计时的 tick 值；未收到时按 (initialRemainingMs - elapsed) 兜底
+  const elapsed = Math.max(0, Date.now() - startedAt.value)
+  const remaining =
+    lastKnownRemainingMs > 0
+      ? lastKnownRemainingMs
+      : Math.max(0, initialRemainingMs.value - elapsed)
+  writeAnswerTime({
+    surveyPath: surveyPath.value,
+    remainingMs: remaining,
+    startedAt: startedAt.value,
+    duration: conf.duration,
+    unit: conf.unit,
+    updatedAt: Date.now()
+  })
+}
+
+const initAnswerTimeOnMount = () => {
+  const conf = answerTimeLimit.value
+  if (!conf || !surveyPath.value) return
+  const existing = readAnswerTime(surveyPath.value)
+  if (existing && existing.duration === conf.duration && existing.unit === conf.unit) {
+    initialRemainingMs.value = Math.max(0, existing.remainingMs)
+  } else {
+    initialRemainingMs.value = unitToMs(conf.duration, conf.unit)
+    initAnswerTime(surveyPath.value, conf)
+  }
+  lastKnownRemainingMs = initialRemainingMs.value
+  // 启用时一律先弹「开始填写」入口（即使剩余 0 也展示，让用户知道）
+  entryDialogVisible.value = true
+  answeringStarted.value = false
+}
+
+const handleStartAnswering = () => {
+  const conf = answerTimeLimit.value
+  if (!conf || !surveyPath.value) return
+  startedAt.value = Date.now()
+  answeringStarted.value = true
+  writeAnswerTime({
+    surveyPath: surveyPath.value,
+    remainingMs: initialRemainingMs.value,
+    startedAt: startedAt.value,
+    duration: conf.duration,
+    unit: conf.unit,
+    updatedAt: Date.now()
+  })
+  // 立即重新计算 surveyStore.enterTime，使「最短时长」校验从「点击开始填写」起算
+  surveyStore.setEnterTime?.()
+}
+
+const handleTick = (remainingMs: number) => {
+  lastKnownRemainingMs = remainingMs
+  // 5s 间隔写回 localStorage
+  if (!persistTimer.value && answerTimeLimit.value?.enabled && answeringStarted.value) {
+    persistTimer.value = window.setInterval(persistRemaining, 5000)
+  }
+}
+
+const handleVisibilityHidden = () => {
+  if (document.visibilityState === 'hidden') {
+    persistRemaining()
+  }
+}
+
+const handleBeforeUnload = () => {
+  persistRemaining()
+}
+
+// === 提交流程 ===
 const validate = (callback: (v: boolean) => void) => {
   const index = 0
   mainRef.value.$refs.formGroup[index].validate(callback)
 }
 
-const normalizationRequestBody = () => {
+const buildRequestBody = (autoSubmit: boolean) => {
   const enterTime = surveyStore.enterTime
   const encryptInfo: any = surveyStore.encryptInfo
   const formValues = surveyStore.formValues
-  const baseConf: any = surveyStore.baseConf
+  const localBaseConf: any = surveyStore.baseConf
 
   const result: any = {
     surveyPath: surveyPath.value,
@@ -96,24 +244,24 @@ const normalizationRequestBody = () => {
     ...whiteData.value
   }
 
-  // 自动回填开启时，记录数据
-  if (baseConf.fillSubmitAnswer) {
+  if (autoSubmit) {
+    result.autoSubmit = true
+  }
+
+  // 自动回填开启时，记录数据（autoSubmit 场景仍然记录用户已填内容）
+  if (localBaseConf.fillSubmitAnswer) {
     clearSurveyData(surveyPath.value)
     clearSurveySubmit(surveyPath.value)
-
     setSurveyData(surveyPath.value, formValues)
     setSurveySubmit(surveyPath.value, 1)
   }
 
-  // 数据加密
   if (encryptInfo?.encryptType) {
     result.encryptType = encryptInfo.encryptType
-
     result.data = encrypt[result.encryptType as 'rsa']({
       data: result.data,
       secretKey: encryptInfo?.data?.secretKey
     })
-
     if (encryptInfo?.data?.sessionId) {
       result.sessionId = encryptInfo.data.sessionId
     }
@@ -124,20 +272,39 @@ const normalizationRequestBody = () => {
   return result
 }
 
-const submitSurvey = async () => {
+const checkMinDuration = (): boolean => {
+  const conf = effectiveAnswerMinDuration.value
+  if (!conf) return true
+  const minMs = unitToMs(conf.duration, conf.unit)
+  // 最短时长以「点击开始填写」时刻起算（若未启用 answerTimeLimit 则退回到 enterTime）
+  const baseTs = startedAt.value > 0 ? startedAt.value : surveyStore.enterTime
+  const elapsed = Math.max(0, Date.now() - baseTs)
+  if (elapsed < minMs) {
+    minDurationDialogVisible.value = true
+    return false
+  }
+  return true
+}
+
+const submitSurvey = async (autoSubmit = false) => {
+  if (submitting.value) return
   if (surveyPath.value.length > 8) {
+    if (autoSubmit) {
+      // 预览态不真正提交，但仍清掉 localStorage 并跳转
+      clearAnswerTime(surveyPath.value)
+    }
     router.push({ name: 'successPage' })
     return
   }
+  submitting.value = true
   try {
-    const params = normalizationRequestBody()
+    const params = buildRequestBody(autoSubmit)
     const res: any = await submitForm(params)
     if (res.code === 200) {
+      clearAnswerTime(surveyPath.value)
       router.replace({ name: 'successPage' })
     } else {
-      alert({
-        title: res.errmsg || '提交失败'
-      })
+      alert({ title: res.errmsg || '提交失败' })
       if (res.code === 9003 && res.data) {
         surveyStore.changeData({ key: res.data.field, value: null })
         questionStore.initOptionCountInfo()
@@ -145,6 +312,8 @@ const submitSurvey = async () => {
     }
   } catch (error) {
     console.log(error)
+  } finally {
+    submitting.value = false
   }
 }
 
@@ -155,12 +324,15 @@ const handleSubmit = () => {
     questionStore.addPageIndex()
     return
   }
+  // 必填校验已在 SubmitButton.submit 中通过 validate 完成
+  // 这里追加最短时长校验
+  if (!checkMinDuration()) return
   if (is_again) {
     confirm({
       title: again_text,
       onConfirm: async () => {
         try {
-          submitSurvey()
+          await submitSurvey(false)
         } catch (error) {
           console.log(error)
         } finally {
@@ -169,9 +341,42 @@ const handleSubmit = () => {
       }
     })
   } else {
-    submitSurvey()
+    submitSurvey(false)
   }
 }
+
+const handleExpire = () => {
+  if (submitting.value) return
+  // 倒计时归零：跳过 FE 必填 + 最短时长校验，直接提交 autoSubmit=true
+  submitSurvey(true)
+}
+
+watch(
+  () => answerTimeLimit.value?.enabled,
+  (enabled) => {
+    if (enabled) {
+      initAnswerTimeOnMount()
+    } else {
+      entryDialogVisible.value = false
+      answeringStarted.value = false
+    }
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  window.addEventListener('beforeunload', handleBeforeUnload)
+  document.addEventListener('visibilitychange', handleVisibilityHidden)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('beforeunload', handleBeforeUnload)
+  document.removeEventListener('visibilitychange', handleVisibilityHidden)
+  if (persistTimer.value != null) {
+    window.clearInterval(persistTimer.value)
+    persistTimer.value = null
+  }
+})
 </script>
 <style scoped lang="scss">
 .index {

--- a/web/src/render/pages/RenderPage.vue
+++ b/web/src/render/pages/RenderPage.vue
@@ -83,7 +83,7 @@ import {
 import {
   type AnswerTimeLimitConf,
   getEffectiveAnswerMinDuration,
-  normalizeUnit,
+  normalizeAnswerTimeConf,
   unitToMs
 } from '../types/answerTimeLimit'
 
@@ -125,21 +125,11 @@ const {
 const surveyPath = computed(() => surveyStore.surveyPath || '')
 
 // === 答题限时 / 最短答题时长 ===
-const normalizeConf = (raw: any): AnswerTimeLimitConf | null => {
-  if (!raw || typeof raw !== 'object' || raw.enabled !== true) return null
-  const duration = typeof raw.duration === 'number' && raw.duration > 0 ? raw.duration : 30
-  return {
-    enabled: true,
-    duration,
-    unit: normalizeUnit(raw.unit)
-  }
-}
-
 const answerTimeLimit = computed<AnswerTimeLimitConf | null>(() =>
-  normalizeConf((baseConf.value as any)?.answerTimeLimit)
+  normalizeAnswerTimeConf((baseConf.value as any)?.answerTimeLimit)
 )
 const answerMinDuration = computed<AnswerTimeLimitConf | null>(() =>
-  normalizeConf((baseConf.value as any)?.answerMinDuration)
+  normalizeAnswerTimeConf((baseConf.value as any)?.answerMinDuration)
 )
 const effectiveAnswerMinDuration = computed<AnswerTimeLimitConf | null>(() =>
   getEffectiveAnswerMinDuration(answerMinDuration.value, answerTimeLimit.value)

--- a/web/src/render/types/answerTimeLimit.ts
+++ b/web/src/render/types/answerTimeLimit.ts
@@ -27,6 +27,10 @@ export const normalizeUnit = (unit: unknown): AnswerTimeUnit => {
   return unit === 'second' ? 'second' : 'minute'
 }
 
+export const isAnswerTimeUnit = (unit: unknown): unit is AnswerTimeUnit => {
+  return unit === 'minute' || unit === 'second'
+}
+
 export const isValidDuration = (value: unknown): value is number => {
   return typeof value === 'number' && Number.isInteger(value) && value > 0
 }
@@ -35,6 +39,24 @@ export const isWithinBounds = (duration: number, unit: AnswerTimeUnit): boolean 
   if (!isValidDuration(duration)) return false
   if (unit === 'minute') return duration <= MAX_MINUTE
   return duration >= MIN_SECOND
+}
+
+export const validateAnswerTimeConf = (raw: unknown): raw is AnswerTimeLimitConf => {
+  if (!raw || typeof raw !== 'object') return false
+  const conf = raw as Partial<AnswerTimeLimitConf>
+  if (conf.enabled !== true) return false
+  if (!isAnswerTimeUnit(conf.unit)) return false
+  if (!isValidDuration(conf.duration)) return false
+  return isWithinBounds(conf.duration, conf.unit)
+}
+
+export const normalizeAnswerTimeConf = (raw: unknown): AnswerTimeLimitConf | null => {
+  if (!validateAnswerTimeConf(raw)) return null
+  return {
+    enabled: true,
+    duration: raw.duration,
+    unit: raw.unit
+  }
 }
 
 export const getEffectiveAnswerMinDuration = (

--- a/web/src/render/types/answerTimeLimit.ts
+++ b/web/src/render/types/answerTimeLimit.ts
@@ -1,0 +1,50 @@
+export type AnswerTimeUnit = 'minute' | 'second'
+
+export interface AnswerTimeLimitConf {
+  enabled: boolean
+  duration: number
+  unit: AnswerTimeUnit
+}
+
+export interface AnswerTimeRecord {
+  surveyPath: string
+  remainingMs: number
+  startedAt: number
+  duration: number
+  unit: AnswerTimeUnit
+  updatedAt: number
+}
+
+export const DEFAULT_DURATION = 30
+export const MAX_MINUTE = 1440
+export const MIN_SECOND = 10
+
+export const unitToMs = (duration: number, unit: AnswerTimeUnit): number => {
+  return unit === 'second' ? duration * 1000 : duration * 60 * 1000
+}
+
+export const normalizeUnit = (unit: unknown): AnswerTimeUnit => {
+  return unit === 'second' ? 'second' : 'minute'
+}
+
+export const isValidDuration = (value: unknown): value is number => {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+export const isWithinBounds = (duration: number, unit: AnswerTimeUnit): boolean => {
+  if (!isValidDuration(duration)) return false
+  if (unit === 'minute') return duration <= MAX_MINUTE
+  return duration >= MIN_SECOND
+}
+
+export const getEffectiveAnswerMinDuration = (
+  minDuration: AnswerTimeLimitConf | null,
+  timeLimit: AnswerTimeLimitConf | null
+): AnswerTimeLimitConf | null => {
+  if (!minDuration?.enabled) return null
+  if (!timeLimit?.enabled) return minDuration
+  return unitToMs(minDuration.duration, minDuration.unit) <
+    unitToMs(timeLimit.duration, timeLimit.unit)
+    ? minDuration
+    : null
+}

--- a/web/src/render/utils/answerTimeStore.ts
+++ b/web/src/render/utils/answerTimeStore.ts
@@ -1,0 +1,97 @@
+import {
+  type AnswerTimeRecord,
+  type AnswerTimeLimitConf,
+  type AnswerTimeUnit,
+  normalizeUnit,
+  unitToMs
+} from '../types/answerTimeLimit'
+
+export const ANSWER_TIME_KEY_PREFIX = 'survey-engine:answer-time:'
+
+const buildKey = (surveyPath: string): string => `${ANSWER_TIME_KEY_PREFIX}${surveyPath}`
+
+const safeStorage = (): Storage | null => {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) return window.localStorage
+  } catch (e) {
+    // localStorage may be unavailable (privacy mode, server-side render)
+  }
+  return null
+}
+
+export const read = (surveyPath: string): AnswerTimeRecord | null => {
+  if (!surveyPath) return null
+  const storage = safeStorage()
+  if (!storage) return null
+  try {
+    const raw = storage.getItem(buildKey(surveyPath))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<AnswerTimeRecord>
+    if (
+      !parsed ||
+      typeof parsed.remainingMs !== 'number' ||
+      typeof parsed.startedAt !== 'number' ||
+      typeof parsed.duration !== 'number'
+    ) {
+      return null
+    }
+    return {
+      surveyPath,
+      remainingMs: parsed.remainingMs,
+      startedAt: parsed.startedAt,
+      duration: parsed.duration,
+      unit: normalizeUnit(parsed.unit),
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now()
+    }
+  } catch (e) {
+    return null
+  }
+}
+
+export const write = (record: AnswerTimeRecord): void => {
+  const storage = safeStorage()
+  if (!storage || !record?.surveyPath) return
+  try {
+    storage.setItem(
+      buildKey(record.surveyPath),
+      JSON.stringify({ ...record, updatedAt: Date.now() })
+    )
+  } catch (e) {
+    // quota exceeded / privacy mode — ignore
+  }
+}
+
+export const clear = (surveyPath: string): void => {
+  if (!surveyPath) return
+  const storage = safeStorage()
+  if (!storage) return
+  try {
+    storage.removeItem(buildKey(surveyPath))
+  } catch (e) {
+    // ignore
+  }
+}
+
+export const init = (
+  surveyPath: string,
+  conf: AnswerTimeLimitConf | null | undefined
+): AnswerTimeRecord | null => {
+  if (!surveyPath || !conf || !conf.enabled) return null
+  const unit: AnswerTimeUnit = normalizeUnit(conf.unit)
+  const duration = typeof conf.duration === 'number' && conf.duration > 0 ? conf.duration : 30
+  const totalMs = unitToMs(duration, unit)
+  const existing = read(surveyPath)
+  if (existing && existing.duration === duration && existing.unit === unit) {
+    return existing
+  }
+  const fresh: AnswerTimeRecord = {
+    surveyPath,
+    remainingMs: totalMs,
+    startedAt: 0,
+    duration,
+    unit,
+    updatedAt: Date.now()
+  }
+  write(fresh)
+  return fresh
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import vueJsx from '@vitejs/plugin-vue-jsx'
+
+// 独立的 vitest 配置：不复用 vite.config.ts 的 MPA / auto-import 插件，
+// 仅保留单测所需的 vue 编译与路径别名，环境用 jsdom。
+export default defineConfig({
+  plugins: [vue(), vueJsx()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@management': fileURLToPath(new URL('./src/management', import.meta.url)),
+      '@materials': fileURLToPath(new URL('./src/materials', import.meta.url)),
+      '@render': fileURLToPath(new URL('./src/render', import.meta.url))
+    }
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,ts,jsx,tsx}']
+  }
+})


### PR DESCRIPTION
### 改动内容

  1. 支持问卷「答题限时」配置：
     - 管理端新增答题限时配置项，支持开启/关闭、填写时长、选择分钟/秒。
     - 答卷端进入问卷时展示限时提示，点击开始后启动倒计时。
     - 倒计时归零后自动提交已填写内容，并标记 `autoSubmit=true`。

  2. 支持「最短答题时长」配置：
     - 管理端新增最短答题时长配置项。
     - 答卷端在未达到最短时长时拦截手动提交，并提示稍后再试。
     - 当最短答题时长大于等于答题限时时，答卷端不启用该最短时长限制，避免配置冲突导致无法提交。

  3. 增强答卷提交链路：
     - c端答题渲染前先校验答题配置是否符合规则，不符合的配置不生效
     - 服务端新增 `autoSubmit` 字段持久化，用于区分超时自动提交和用户手动提交。手动提交需经过服务端增加校验

  4. 增加配置兜底与状态恢复：
     - 答卷端将剩余答题时间写入 localStorage，支持刷新或重新进入后继续使用剩余时间。
     - 修复管理端 schema 初始化时复用旧对象导致配置跨问卷残留的问题。

  5. 补充测试：
     - 新增服务端答题时长配置 normalize、自动提交、必填校验相关单测。
     - 新增前端限时配置组件、倒计时展示、限时提示弹窗、最短时长生效逻辑、localStorage 状态恢复相关 Vitest 单测。