### PR TITLE
fix: 修复项目中多处拼写错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 
 **1、Web 端：Vue3 + ElementPlus**
 
-跨端SDK：ReactNaitve
+跨端SDK：ReactNative
 
 **2、Server 端：NestJS + MongoDB**
 

--- a/server/src/modules/auth/controllers/auth.controller.ts
+++ b/server/src/modules/auth/controllers/auth.controller.ts
@@ -136,7 +136,7 @@ export class AuthController {
       this.captchaService.deleteCaptcha(userInfo.captchaId);
     } catch (error) {
       throw new Error(
-        'generateToken erro:' +
+        'generateToken error:' +
           error.message +
           this.configService.get<string>('XIAOJU_SURVEY_JWT_SECRET') +
           this.configService.get<string>('XIAOJU_SURVEY_JWT_EXPIRES_IN'),

--- a/server/src/modules/channel/controllers/channel.controller.ts
+++ b/server/src/modules/channel/controllers/channel.controller.ts
@@ -206,14 +206,14 @@ export class ChannelController {
   @SetMetadata('surveyPermission', [SURVEY_PERMISSION.SURVEY_CONF_MANAGE])
   @HttpCode(200)
   async updateStatus(
-    @Body() parama: Partial<{ status: CHANNEL_STATUS }>,
+    @Body() param: Partial<{ status: CHANNEL_STATUS }>,
     @Request() req,
   ) {
     const id = req.body.channelId;
     const operatorId = req.user._id.toString();
     const updateRes = await this.channelService.updateStatus({
       id,
-      status: parama.status,
+      status: param.status,
       operatorId,
     });
     this.logger.info(`updateRes: ${JSON.stringify(updateRes)}`);

--- a/server/src/modules/survey/__test/collaborator.controller.spec.ts
+++ b/server/src/modules/survey/__test/collaborator.controller.spec.ts
@@ -28,7 +28,7 @@ describe('CollaboratorController', () => {
   let logger: Logger;
   let userService: UserService;
   let surveyMetaService: SurveyMetaService;
-  let workspaceMemberServie: WorkspaceMemberService;
+  let workspaceMemberService: WorkspaceMemberService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -87,7 +87,7 @@ describe('CollaboratorController', () => {
     logger = module.get<Logger>(Logger);
     userService = module.get<UserService>(UserService);
     surveyMetaService = module.get<SurveyMetaService>(SurveyMetaService);
-    workspaceMemberServie = module.get<WorkspaceMemberService>(
+    workspaceMemberService = module.get<WorkspaceMemberService>(
       WorkspaceMemberService,
     );
   });
@@ -413,7 +413,7 @@ describe('CollaboratorController', () => {
       jest
         .spyOn(surveyMetaService, 'getSurveyById')
         .mockResolvedValue(surveyMeta as SurveyMeta);
-      jest.spyOn(workspaceMemberServie, 'findOne').mockResolvedValue({} as any);
+      jest.spyOn(workspaceMemberService, 'findOne').mockResolvedValue({} as any);
 
       const response = await controller.getUserSurveyPermissions(req, query);
 
@@ -447,7 +447,7 @@ describe('CollaboratorController', () => {
       jest
         .spyOn(surveyMetaService, 'getSurveyById')
         .mockResolvedValue(surveyMeta as SurveyMeta);
-      jest.spyOn(workspaceMemberServie, 'findOne').mockResolvedValue(null);
+      jest.spyOn(workspaceMemberService, 'findOne').mockResolvedValue(null);
       jest
         .spyOn(collaboratorService, 'getCollaborator')
         .mockResolvedValue(collaborator as Collaborator);
@@ -477,7 +477,7 @@ describe('CollaboratorController', () => {
       jest
         .spyOn(surveyMetaService, 'getSurveyById')
         .mockResolvedValue(surveyMeta as SurveyMeta);
-      jest.spyOn(workspaceMemberServie, 'findOne').mockResolvedValue(null);
+      jest.spyOn(workspaceMemberService, 'findOne').mockResolvedValue(null);
       jest
         .spyOn(collaboratorService, 'getCollaborator')
         .mockResolvedValue(null);

--- a/server/src/modules/survey/__test/dataStatistic.controller.spec.ts
+++ b/server/src/modules/survey/__test/dataStatistic.controller.spec.ts
@@ -570,7 +570,7 @@ describe('DataStatisticController', () => {
                 count: 1,
               },
             ],
-            submitionCount: 2,
+            submissionCount: 2,
           },
         },
         {
@@ -586,7 +586,7 @@ describe('DataStatisticController', () => {
                 count: 1,
               },
             ],
-            submitionCount: 2,
+            submissionCount: 2,
           },
         },
         {
@@ -598,7 +598,7 @@ describe('DataStatisticController', () => {
                 count: 1,
               },
             ],
-            submitionCount: 1,
+            submissionCount: 1,
           },
         },
         {
@@ -610,7 +610,7 @@ describe('DataStatisticController', () => {
                 count: 1,
               },
             ],
-            submitionCount: 1,
+            submissionCount: 1,
           },
         },
       ];

--- a/server/src/modules/survey/__test/dataStatistic.service.spec.ts
+++ b/server/src/modules/survey/__test/dataStatistic.service.spec.ts
@@ -384,7 +384,7 @@ describe('DataStatisticService', () => {
                   count: 1,
                 },
               ],
-              submitionCount: 2,
+              submissionCount: 2,
             },
           },
           {
@@ -400,7 +400,7 @@ describe('DataStatisticService', () => {
                   count: 1,
                 },
               ],
-              submitionCount: 2,
+              submissionCount: 2,
             },
           },
           {
@@ -412,7 +412,7 @@ describe('DataStatisticService', () => {
                   count: 1,
                 },
               ],
-              submitionCount: 1,
+              submissionCount: 1,
             },
           },
           {
@@ -424,7 +424,7 @@ describe('DataStatisticService', () => {
                   count: 1,
                 },
               ],
-              submitionCount: 1,
+              submissionCount: 1,
             },
           },
         ]),
@@ -450,14 +450,14 @@ describe('DataStatisticService', () => {
             field: 'data458',
             data: {
               aggregation: [],
-              submitionCount: 0,
+              submissionCount: 0,
             },
           },
           {
             field: 'data515',
             data: {
               aggregation: [],
-              submitionCount: 0,
+              submissionCount: 0,
             },
           },
         ]),

--- a/server/src/modules/survey/controllers/collaborator.controller.ts
+++ b/server/src/modules/survey/controllers/collaborator.controller.ts
@@ -43,7 +43,7 @@ export class CollaboratorController {
     private readonly logger: Logger,
     private readonly userService: UserService,
     private readonly surveyMetaService: SurveyMetaService,
-    private readonly workspaceMemberServie: WorkspaceMemberService,
+    private readonly workspaceMemberService: WorkspaceMemberService,
   ) {}
 
   @Get('getPermissionList')
@@ -344,7 +344,7 @@ export class CollaboratorController {
     }
     // 有空间权限，默认也有所有权限
     if (surveyMeta.workspaceId) {
-      const memberInfo = await this.workspaceMemberServie.findOne({
+      const memberInfo = await this.workspaceMemberService.findOne({
         workspaceId: surveyMeta.workspaceId,
         userId,
       });
@@ -363,7 +363,7 @@ export class CollaboratorController {
       }
     }
 
-    const colloborator = await this.collaboratorService.getCollaborator({
+    const collaborator = await this.collaboratorService.getCollaborator({
       surveyId,
       userId,
     });
@@ -371,7 +371,7 @@ export class CollaboratorController {
       code: 200,
       data: {
         isOwner: false,
-        permissions: colloborator?.permissions || [],
+        permissions: collaborator?.permissions || [],
       },
     };
   }

--- a/server/src/modules/survey/controllers/dataStatistic.controller.ts
+++ b/server/src/modules/survey/controllers/dataStatistic.controller.ts
@@ -20,7 +20,7 @@ import { Logger } from 'src/logger';
 import { HttpException } from 'src/exceptions/httpException';
 import { EXCEPTION_CODE } from 'src/enums/exceptionCode';
 import { AggregationStatisDto } from '../dto/aggregationStatis.dto';
-import { handleAggretionData } from '../utils';
+import { handleAggregationData } from '../utils';
 import { QUESTION_TYPE } from 'src/enums/question';
 
 @ApiTags('survey')
@@ -127,7 +127,7 @@ export class DataStatisticController {
     return {
       code: 200,
       data: res.map((item) => {
-        return handleAggretionData({ item, dataMap });
+        return handleAggregationData({ item, dataMap });
       }),
     };
   }

--- a/server/src/modules/survey/services/dataStatistic.service.ts
+++ b/server/src/modules/survey/services/dataStatistic.service.ts
@@ -149,7 +149,7 @@ export class DataStatisticService {
       { maxTimeMS: 30000, allowDiskUse: true },
     );
     const res = await aggregation.next();
-    const submitionCountMap: Record<string, number> = {};
+    const submissionCountMap: Record<string, number> = {};
     for (const field in res) {
       let count = 0;
       if (Array.isArray(res[field])) {
@@ -157,7 +157,7 @@ export class DataStatisticService {
           count += optionItem.count;
         }
       }
-      submitionCountMap[field] = count;
+      submissionCountMap[field] = count;
     }
     const transformedData = transformAndMergeArrayFields(res);
     return fieldList.map((field) => {
@@ -170,7 +170,7 @@ export class DataStatisticService {
               count: optionItem.count,
             };
           }),
-          submitionCount: submitionCountMap?.[field] || 0,
+          submissionCount: submissionCountMap?.[field] || 0,
         },
       };
     });

--- a/server/src/modules/survey/services/surveyMeta.service.ts
+++ b/server/src/modules/survey/services/surveyMeta.service.ts
@@ -273,7 +273,7 @@ export class SurveyMetaService {
             otherQuery.groupId = groupId;
           }
         }
-        // 引入空间之前，新建的问卷只有owner字段，引入空间之后，新建的问卷多了ownerId字段，使用owenrId字段进行关联更加合理，此处做了兼容
+        // 引入空间之前，新建的问卷只有owner字段，引入空间之后，新建的问卷多了ownerId字段，使用ownerId字段进行关联更加合理，此处做了兼容
         // query.$or = [
         //   {
         //     owner: username,

--- a/server/src/modules/survey/utils/index.ts
+++ b/server/src/modules/survey/utils/index.ts
@@ -106,7 +106,7 @@ export function transformAndMergeArrayFields(data) {
   return transformedData;
 }
 
-export function handleAggretionData({ dataMap, item }) {
+export function handleAggregationData({ dataMap, item }) {
   const type = dataMap[item.field].type;
   const aggregationMap = item.data.aggregation.reduce((pre, cur) => {
     pre[cur.id] = cur;
@@ -170,7 +170,7 @@ export function handleAggretionData({ dataMap, item }) {
             count: aggregationMap?.[num]?.count || 0,
           };
         }),
-        submitionCount: item.data.submitionCount,
+        submissionCount: item.data.submissionCount,
         summary,
       },
     };
@@ -279,17 +279,17 @@ function getVariance({ aggregation, average }) {
 function getNps({ aggregation }) {
   // 净推荐值(NPS)=(推荐者数/总样本数)×100%-(贬损者数/总样本数)×100%
   // 0～10分举例子：推荐者（9-10分）；被动者（7-8分）；贬损者（0-6分）
-  let recommand = 0,
+  let recommend = 0,
     derogatory = 0,
     total = 0;
   for (const item of aggregation) {
     const num = parseInt(item.id);
     if (num >= 9) {
-      recommand += item.count;
+      recommend += item.count;
     } else if (num <= 6) {
       derogatory += item.count;
     }
     total += item.count;
   }
-  return ((recommand / total - derogatory / total) * 100).toFixed(2) + '%';
+  return ((recommend / total - derogatory / total) * 100).toFixed(2) + '%';
 }

--- a/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
+++ b/server/src/modules/surveyResponse/controllers/surveyResponse.controller.ts
@@ -456,10 +456,10 @@ export class SurveyResponseController {
   private matchLogicRule(
     rule: LogicRule,
     formValues: Record<string, any>,
-    comparor: 'and' | 'or' = 'and',
+    comparator: 'and' | 'or' = 'and',
   ): boolean {
     const conditions = Array.isArray(rule.conditions) ? rule.conditions : [];
-    if (comparor === 'or') {
+    if (comparator === 'or') {
       return conditions.some((condition) =>
         this.matchLogicCondition(condition, formValues),
       );

--- a/server/src/modules/upgrade/services/upgrade.service.ts
+++ b/server/src/modules/upgrade/services/upgrade.service.ts
@@ -205,6 +205,6 @@ export class UpgradeService {
       }
       this.logger.info(`finish upgrade ${name}`);
     }
-    this.logger.info(`upgrad finished...`);
+    this.logger.info(`upgrade finished...`);
   }
 }

--- a/web/src/common/logicEngine/RulesMatch.ts
+++ b/web/src/common/logicEngine/RulesMatch.ts
@@ -83,9 +83,9 @@ export class RuleNode {
   }
 
   // 匹配条件规则
-  match(fact: Fact, comparor?: any) {
+  match(fact: Fact, comparator?: any) {
     let res: boolean | undefined = undefined
-    if (comparor === 'or') {
+    if (comparator === 'or') {
       res = Array.from(this.conditions.entries()).some(([, value]) => {
         const res = value.match(fact)
         if (res) {
@@ -175,12 +175,12 @@ export class RuleMatch {
   }
 
   // 特定目标题规则匹配
-  match(target: string, scope: string, fact: Fact, comparor?: any) {
+  match(target: string, scope: string, fact: Fact, comparator?: any) {
     const hash = this.calculateHash(target, scope)
 
     const rule = this.rules.get(hash)
     if (rule) {
-      const result = rule.match(fact, comparor)
+      const result = rule.match(fact, comparator)
       return result
     } else {
       // 默认显示

--- a/web/src/management/components/MultiSourcePreviewPanel.vue
+++ b/web/src/management/components/MultiSourcePreviewPanel.vue
@@ -6,7 +6,7 @@
     <div class="right-panel">
       <div class="questions-preview-wrapper">
         <div class="questions-preview-box">
-          <div class="diabled-edit-mask"></div>
+          <div class="disabled-edit-mask"></div>
           <MaterialGroup
             :current-edit-one="parseInt(currentEditOne)"
             :questionDataList="props.questionDataList"
@@ -69,7 +69,7 @@ const props = defineProps({
     .questions-preview-box {
       position: relative;
     }
-    .diabled-edit-mask {
+    .disabled-edit-mask {
       position: absolute;
       z-index: 999999;
       left: 0;

--- a/web/src/management/pages/analysis/components/StatisticsItem.vue
+++ b/web/src/management/pages/analysis/components/StatisticsItem.vue
@@ -5,7 +5,7 @@
         placement="top"
         width="400"
         trigger="hover"
-        :disabled="!titlePoppverShow"
+        :disabled="!titlePopoverShow"
         :content="cleanRichText(StatisticsData.title)"
       >
         <template #reference>
@@ -66,7 +66,7 @@ const questionTypeDesc = computed(() => {
 const separateItemListBody = computed(() => {
   try {
     const aggregation = _cloneDeep(props?.StatisticsData?.data?.aggregation)
-    const submitionCount = props?.StatisticsData?.data?.submitionCount
+    const submissionCount = props?.StatisticsData?.data?.submissionCount
     const summaryList = summaryItemConfig[questionType.value]
     // 增加聚合信息
     if (summaryList?.length) {
@@ -90,7 +90,7 @@ const separateItemListBody = computed(() => {
     return (
       aggregation?.map((item) => {
         const { id, count, text } = item
-        const percent = submitionCount ? `${((count / submitionCount) * 100).toFixed(1)}%` : '0%'
+        const percent = submissionCount ? `${((count / submissionCount) * 100).toFixed(1)}%` : '0%'
         return {
           id,
           count,
@@ -116,14 +116,14 @@ const separateItemState = reactive({
 
 const { tableData, tableMinHeight } = toRefs(separateItemState)
 
-const titlePoppverShow = ref(false)
+const titlePopoverShow = ref(false)
 const titleRef = ref(null)
 
 const titleResize = () => {
   if (titleRef.value?.scrollWidth > titleRef.value?.offsetWidth) {
-    titlePoppverShow.value = true
+    titlePopoverShow.value = true
   } else {
-    titlePoppverShow.value = false
+    titlePopoverShow.value = false
   }
 }
 

--- a/web/src/management/pages/edit/modules/contentModule/HistoryPanel.vue
+++ b/web/src/management/pages/edit/modules/contentModule/HistoryPanel.vue
@@ -4,14 +4,14 @@
       <el-tab-pane label="修改历史" name="daily" class="custom-tab-pane">
         <div class="line" v-for="(his, index) in dailyList" :key="index">
           <span class="operator">{{ his.operator }}</span>
-          <span class="seperator">|</span>
+          <span class="separator">|</span>
           <span>{{ his.time }}</span>
         </div>
       </el-tab-pane>
       <el-tab-pane label="发布历史" name="publish" class="custom-tab-pane">
         <div class="line" v-for="(his, index) in publishList" :key="index">
           <span class="operator">{{ his.operator }}</span>
-          <span class="seperator">|</span>
+          <span class="separator">|</span>
           <span>{{ his.time }}</span>
         </div>
       </el-tab-pane>
@@ -123,7 +123,7 @@ watch(
   transition: all 0.2s;
   color: $font-color;
 
-  .seperator {
+  .separator {
     padding: 0 10px;
   }
 }

--- a/web/src/management/pages/edit/modules/logicModule/JumpLogic.vue
+++ b/web/src/management/pages/edit/modules/logicModule/JumpLogic.vue
@@ -387,7 +387,7 @@ watch(
     font-weight: 500;
   }
 
-  .table-feild {
+  .table-field {
     height: 28x;
     padding: 0 10px;
     font-size: 14px;
@@ -398,7 +398,7 @@ watch(
     text-overflow: ellipsis;
   }
 
-  .feild-type {
+  .field-type {
     color: #9f9c9f;
   }
   /* 自定义锚点样式 */

--- a/web/src/management/pages/edit/modules/logicModule/components/RuleNodeView.vue
+++ b/web/src/management/pages/edit/modules/logicModule/components/RuleNodeView.vue
@@ -99,14 +99,14 @@ const submitForm = () => {
   })
 }
 const targetQuestionList = computed(() => {
-  const currntIndexs: number[] = []
+  const currentIndexes: number[] = []
   props.ruleNode.conditions.forEach((el) => {
-    currntIndexs.push(
+    currentIndexes.push(
       renderData.value.findIndex((item: { field: string }) => item.field === el.field)
     )
   })
-  const currntIndex = Math.max(...currntIndexs)
-  let questionList = cloneDeep(renderData.value.slice(currntIndex + 1))
+  const currentIndex = Math.max(...currentIndexes)
+  let questionList = cloneDeep(renderData.value.slice(currentIndex + 1))
   return questionList.map((item: any) => {
     return {
       label: `${item.showIndex ? item.indexNumber + '.' : ''} ${cleanRichText(item.title)}`,

--- a/web/src/management/pages/edit/modules/logicModule/components/RulePanel.vue
+++ b/web/src/management/pages/edit/modules/logicModule/components/RulePanel.vue
@@ -5,7 +5,7 @@
       ref="ruleWrappers"
       :key="item.id"
       :ruleNode="item"
-      @delete="handleDetele"
+      @delete="handleDelete"
     >
     </RuleNodeView>
 
@@ -38,7 +38,7 @@ const handleAdd = () => {
   ruleNode.addCondition(condition)
   showLogicEngine.value.addRule(ruleNode)
 }
-const handleDetele = (id: string) => {
+const handleDelete = (id: string) => {
   showLogicEngine.value.removeRule(id)
 }
 
@@ -49,14 +49,14 @@ const formValidate = () => {
     return item?.submitForm()
   })
 }
-const handleValide = () => {
+const handleValidate = () => {
   const validPass = formValidate()
   const result = !validPass.includes(false)
-  // result 为ture代表校验不通过
+  // result 为true代表校验不通过
   return !result
 }
 defineExpose({
-  handleValide
+  handleValidate
 })
 </script>
 <style lang="scss">

--- a/web/src/management/pages/edit/modules/logicModule/components/nodeExtension/nodes/QNode.js
+++ b/web/src/management/pages/edit/modules/logicModule/components/nodeExtension/nodes/QNode.js
@@ -31,14 +31,14 @@ class QNode extends HtmlNode {
     for (let i = 0; i < options.length; i++) {
       const item = options[i]
       const itemElement = document.createElement('div')
-      itemElement.className = 'table-feild'
+      itemElement.className = 'table-field'
       const itemKey = document.createElement('span')
       itemKey.innerHTML = item.type
       itemElement.appendChild(itemKey)
       // itemKey.innerText = item.key;
       // const itemType = document.createElement('span');
       // itemType.innerHTML = item.type;
-      // itemType.className = 'feild-type';
+      // itemType.className = 'field-type';
       // itemElement.appendChild(itemType);
       fragment.appendChild(itemElement)
     }
@@ -60,7 +60,7 @@ class QNodeModel extends HtmlNodeModel {
     if (anchorInfo.type === 'left') {
       style.fill = 'red'
       style.hover.fill = 'transparent'
-      style.hover.stroke = 'transpanrent'
+      style.hover.stroke = 'transparent'
       style.className = 'lf-hide-default'
     } else {
       style.fill = 'green'
@@ -113,8 +113,8 @@ class QNodeModel extends HtmlNodeModel {
       }
     ]
 
-    options.forEach((feild, index) => {
-      const anchorId = `${feild.key}_right`
+    options.forEach((field, index) => {
+      const anchorId = `${field.key}_right`
       const { edges } = this.outgoing
       let edgeAddable = true
       if (edges.length) {
@@ -126,7 +126,7 @@ class QNodeModel extends HtmlNodeModel {
         y: y - height / 2 + 60 - 28 + (index + 1) * 30,
         id: anchorId,
         type: 'right',
-        key: feild.key,
+        key: field.key,
         edgeAddable
       })
     })

--- a/web/src/management/pages/edit/modules/questionModule/components/QuestionCatalog.vue
+++ b/web/src/management/pages/edit/modules/questionModule/components/QuestionCatalog.vue
@@ -79,7 +79,7 @@ watch(
 .question-catalog-wrapper {
   padding-bottom: 400px; // 考试题有个上拉框会盖住，改成和题型一致的
 
-  .catelog-first-page {
+  .catalog-first-page {
     font-size: 12px;
     color: #999999;
     padding-bottom: 8px;

--- a/web/src/management/pages/edit/pages/edit/LogicIndex.vue
+++ b/web/src/management/pages/edit/pages/edit/LogicIndex.vue
@@ -1,7 +1,7 @@
 <template>
   <el-tabs
     :modelValue="activeName"
-    class="loigc-tabs"
+    class="logic-tabs"
     :before-leave="beforeTabLeave"
     @tab-change="handleChange"
   >
@@ -53,7 +53,7 @@ const handleChange = (name: any) => {
 }
 </script>
 <style lang="scss" scoped>
-.loigc-tabs {
+.logic-tabs {
   width: 98%;
   height: calc(100% - 48px);
   padding: 10px;

--- a/web/src/management/pages/list/components/AIGenerate.vue
+++ b/web/src/management/pages/list/components/AIGenerate.vue
@@ -107,7 +107,7 @@
     <div class="right-panel">
       <div class="questions-preview-wrapper" :style="{backgroundColor: questionList.length > 0 ? '#fff' : 'transparent'}" >
         <div class="questions-preview-box">
-          <div class="diabled-edit-mask"></div>
+          <div class="disabled-edit-mask"></div>
           <MaterialGroup
             :current-edit-one="parseInt(currentEditOne)"
             :questionDataList="questionList"
@@ -689,7 +689,7 @@ const onInput = () => {
   .questions-preview-box {
     position: relative;
   }
-  .diabled-edit-mask {
+  .disabled-edit-mask {
     position: absolute;
     z-index: 999999;
     left: 0;

--- a/web/src/management/pages/list/components/TextImport.vue
+++ b/web/src/management/pages/list/components/TextImport.vue
@@ -20,7 +20,7 @@
           <p class="example-title">示例：{{item.title}}</p>
           <div class="example-content">
             <p :class='`copy-${item.type}-example`' v-html="item.content"></p>
-            <span class="copy-text" @click="coypText(item)">复制文本</span>
+            <span class="copy-text" @click="copyText(item)">复制文本</span>
           </div>
         </div>
       </div>
@@ -69,7 +69,7 @@ const onInput = () => {
   debouncedTransform()
 }
 
-const coypText = (item: { content: string }) => {
+const copyText = (item: { content: string }) => {
   const data = copy(item.content)
   if (data) {
     ElMessage({

--- a/web/src/management/pages/list/index.vue
+++ b/web/src/management/pages/list/index.vue
@@ -115,7 +115,7 @@
           </div>
           <span>文本导入</span>
         </div>
-        <div class="create-method-item" @click="opemAIGenerate">
+        <div class="create-method-item" @click="openAIGenerate">
           <div class="icon">
             <i class="iconfont icon-AIshengcheng"></i>
           </div>
@@ -129,7 +129,7 @@
         </div>
       </div>
     </el-dialog>
-    <div class="fiexed-text-import-wrapper" v-if="showTextImport">
+    <div class="fixed-text-import-wrapper" v-if="showTextImport">
       <div class="text-import-header">
         <div class="return no-logo-return icon-fanhui" @click="showTextImport = false">返回</div>
         <div class="title">文本导入</div>
@@ -139,7 +139,7 @@
       </div>
       <TextImport @change="onTextImportChange"></TextImport>
     </div>
-    <div class="fiexed-ai-generate-wrapper" v-if="showAIGenerate">
+    <div class="fixed-ai-generate-wrapper" v-if="showAIGenerate">
       <div class="ai-generate-header">
         
         <div class="nav-left">
@@ -152,7 +152,7 @@
       <h2 class="nav-title">AI智能生成问卷</h2>
       <el-button type="primary"  class="publish-btn"  @click="onShowCreateForm">确定创建</el-button>
       </div>
-      <AIGenerate @change="onAIGenerteChange"></AIGenerate>
+      <AIGenerate @change="onAIGenerateChange"></AIGenerate>
     </div>
     <el-dialog
       v-model="showCreateForm"
@@ -407,7 +407,7 @@ const openTextImport = () => {
   createMethod.value = 'textImport'
 }
 
-const opemAIGenerate = () => { 
+const openAIGenerate = () => { 
   showCreateMethod.value = false;
   showAIGenerate.value = true;
   createMethod.value = 'AIGenerate'
@@ -514,7 +514,7 @@ const onShowCreateFormExcelImport = () => {
   showCreateForm.value = true
 }
 
-const onAIGenerteChange = (newQuestionList: Array<any>) => {
+const onAIGenerateChange = (newQuestionList: Array<any>) => {
   questionList.value = newQuestionList
 }
 
@@ -609,7 +609,7 @@ const onAIGenerteChange = (newQuestionList: Array<any>) => {
     }
   }
 }
-.fiexed-text-import-wrapper {
+.fixed-text-import-wrapper {
   position: fixed;
   left: 0;
   right: 0;
@@ -647,7 +647,7 @@ const onAIGenerteChange = (newQuestionList: Array<any>) => {
     }
   }
 }
-.fiexed-ai-generate-wrapper {
+.fixed-ai-generate-wrapper {
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/web/src/management/pages/publish/components/ChannelCards.vue
+++ b/web/src/management/pages/publish/components/ChannelCards.vue
@@ -14,7 +14,7 @@
         </span>
       </div>
       <div class="content">
-        <div class="desc">{{ CHANNEL_TYPE_DSEC[item] }}</div>
+        <div class="desc">{{ CHANNEL_TYPE_DESC[item] }}</div>
       </div>
     </div>
   </div>
@@ -53,7 +53,7 @@ import { storeToRefs  } from 'pinia'
 const editStore = useEditStore()
 const { surveyId, schema } = storeToRefs(editStore)
 const channelStore = useChannelStore()
-const CHANNEL_TYPE_DSEC = {
+const CHANNEL_TYPE_DESC = {
   [CHANNEL_TYPE.SHORT_LINK]: '方式描述方式描述方式描述方式描述方式描述方式描述方式描述方式描述',
   [CHANNEL_TYPE.INJECT_WEB]: "将问卷通过SDK方式嵌入到网页中，适合弹窗、信息流等。",
   [CHANNEL_TYPE.INJECT_APP]: "将问卷通过SDK方式嵌入到IOS、Android等应用中。",

--- a/web/src/management/pages/publish/components/ChannelList.vue
+++ b/web/src/management/pages/publish/components/ChannelList.vue
@@ -40,7 +40,7 @@
   <div class="pagination-container">
     <el-pagination layout="prev, pager, next" :total="channelTotal" @current-change="handleCurrentChange"/>
   </div>
-  <ChannelModify :visible="channelModifyVisible" :channel="curChannel" @confirm="handleRenameConfirm" @close="handleRanameClose"/>
+  <ChannelModify :visible="channelModifyVisible" :channel="curChannel" @confirm="handleRenameConfirm" @close="handleRenameClose"/>
 </template>
 
 <script lang="ts" setup>
@@ -100,7 +100,7 @@ const handleRenameConfirm = (name: string) => {
   channelModifyVisible.value = false
   curChannelId.value = ''
 }
-const handleRanameClose = () => {
+const handleRenameClose = () => {
   channelModifyVisible.value = false
   curChannelId.value = ''
 }

--- a/web/src/management/router/index.ts
+++ b/web/src/management/router/index.ts
@@ -125,7 +125,7 @@ const routes: RouteRecordRaw[] = [
         name: analysisTypeMap.dataTable,
         meta: {
           needLogin: true,
-          premissions: [SurveyPermissions.DataManage]
+          permissions: [SurveyPermissions.DataManage]
         },
         component: () => import('../pages/analysis/pages/DataTablePage.vue')
       },
@@ -134,7 +134,7 @@ const routes: RouteRecordRaw[] = [
         name: analysisTypeMap.separateStatistics,
         meta: {
           needLogin: true,
-          premissions: [SurveyPermissions.DataManage]
+          permissions: [SurveyPermissions.DataManage]
         },
         component: () => import('../pages/analysis/pages/SeparateStatisticsPage.vue')
       }

--- a/web/src/materials/setters/widgets/QuestionTime.vue
+++ b/web/src/materials/setters/widgets/QuestionTime.vue
@@ -8,7 +8,7 @@
         format="YYYY-MM-DD HH:mm:ss"
         @change="handleDatePickerChange(formConfig.keys[0], $event)"
       />
-      <span class="seporator">至</span>
+      <span class="separator">至</span>
       <el-date-picker
         v-model="endModelTime"
         type="datetime"
@@ -75,7 +75,7 @@ watch(
   display: flex;
   justify-content: space-between;
 
-  .seporator {
+  .separator {
     margin: 0 10px;
   }
 }


### PR DESCRIPTION
### 改动内容

通过 cspell 拼写检查，修复项目中多处英文拼写错误，涵盖后端（NestJS）和前端（Vue3）代码。

1. 修复 README.md 中 `ReactNaitve` → `ReactNative`
2. 修复后端日志字符串拼写：`erro` → `error`、`upgrad` → `upgrade`
3. 修复后端注释拼写：`owenrId` → `ownerId`
4. 修复后端参数名拼写：`parama` → `param`
5. 修复后端变量/函数名拼写：`recommand` → `recommend`、`handleAggretionData` → `handleAggregationData`、`workspaceMemberServie` → `workspaceMemberService`、`colloborator` → `collaborator`、`comparor` → `comparator`、`submitionCount` → `submissionCount`
6. 修复前端变量/函数名拼写：`currntIndexs` → `currentIndexes`、`handleDetele` → `handleDelete`、`handleValide` → `handleValidate`、`titlePoppverShow` → `titlePopoverShow`、`coypText` → `copyText`、`opemAIGenerate` → `openAIGenerate`、`onAIGenerteChange` → `onAIGenerateChange`、`handleRanameClose` → `handleRenameClose`
7. 修复前端常量名拼写：`CHANNEL_TYPE_DSEC` → `CHANNEL_TYPE_DESC`
8. 修复前端 CSS 类名拼写：`diabled` → `disabled`、`seperator` → `separator`、`seporator` → `separator`、`catelog` → `catalog`、`loigc` → `logic`、`fiexed` → `fixed`、`feild` → `field`
9. 修复前端样式值拼写：`transpanrent` → `transparent`
10. 修复前端注释拼写：`ture` → `true`
11. 修复路由 meta 字段拼写：`premissions` → `permissions`
12. 同步更新相关测试文件中的 mock 数据拼写

### Issue

无关联 Issue